### PR TITLE
Create glfwException class and add to engine.cc

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -6,8 +6,8 @@
 
 #include "engine.h"
 
-// Standard Library includes
-#include <exception>
+// Exception includes
+#include "exceptions.h"
 
 // Unit Testing includes
 #include "doctest.h"
@@ -87,7 +87,7 @@ static int _luaPanic(lua_State *L)
     msg = "error object is not a string";
   }
   LOG_S(ERROR) << "unprotected error in call to Lua API (" << msg << ")";
-  throw std::exception();
+  throw std::runtime_error(msg);
 }
 
 engine::engine(int argc, char *argv[])
@@ -100,7 +100,7 @@ engine::engine(int argc, char *argv[])
   _luaState = lua_newstate(_luaAlloc, nullptr);
   if (!_luaState) {
     LOG_S(ERROR) << "Could not initialize Lua: Out of memory";
-    throw std::exception();
+    throw std::runtime_error("Out of memory");
   }
   lua_atpanic(_luaState, &_luaPanic);
   lua_setwarnf(_luaState, _luaWarnFunction, nullptr);
@@ -110,7 +110,7 @@ engine::engine(int argc, char *argv[])
   if (!glfwInit()) {
     LOG_S(ERROR) << "Could not initialize GLFW: Platform does not meet minimum "
                     "requirements for GLFW initialization";
-    throw std::exception();
+    throw glfwException();
   }
   LOG_S(INFO) << "GLFW library loaded";
   glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
@@ -118,7 +118,7 @@ engine::engine(int argc, char *argv[])
   if (!_window) {
     LOG_S(ERROR) << "GLFW: Window creation failed";
     glfwTerminate();
-    throw std::exception();
+    throw glfwException();
   }
   LOG_S(INFO) << "GLFW: Game window created (640x480)";
   glfwSetKeyCallback(_window, engine::_keyCallback);

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -1,0 +1,43 @@
+// This document is licensed according to the LGPL v2.1 license
+// Consult the LICENSE file in the root project directory for details
+
+#ifndef NEBULA_EXCEPTIONS_H
+#define NEBULA_EXCEPTIONS_H
+
+#include <stdexcept>
+#include <string>
+
+class glfwException : public std::runtime_error {
+  std::string _description;
+  int _code;
+
+public:
+  explicit glfwException() : std::runtime_error("")
+  {
+    const char *_desc;
+    _code        = glfwGetError(&_desc);
+    _description = _desc;
+  }
+  explicit glfwException(const glfwException &other) noexcept
+      : std::runtime_error("")
+  {
+    _description = other._description;
+    _code        = other._code;
+  }
+  virtual const char *what() const noexcept
+  {
+    return _description.c_str();
+  }
+  glfwException &operator=(const glfwException &other) noexcept
+  {
+    _description = other._description;
+    _code        = other._code;
+    return *this;
+  }
+  bool operator==(int other) noexcept
+  {
+    return _code == other;
+  }
+};
+
+#endif // NEBULA_EXCEPTIONS_H


### PR DESCRIPTION
Lua exception handling in depth will have to wait until later, if I ever 
fully implement it. Converting the exceptions thrown by Lua 
implementation to std::runtime_error for at least a little extra 
clarity, while also passing the error messages. Later will need to catch 
all such errors and send them to Loguru to consolidate error logging.