### PR TITLE
Pipeline class and Shader module loading

### DIFF
--- a/src/graphics.h
+++ b/src/graphics.h
@@ -9,6 +9,7 @@
 
 #include <vector>
 #include <optional>
+#include <string>
 
 namespace nebula {
 
@@ -92,6 +93,19 @@ public:
   {
     return _window;
   }
+
+  class pipeline {
+  private:
+    static std::vector<char> readFile(const std::string &filename);
+    VkShaderModule createShaderModule(
+        VkDevice device, const std::vector<char> &code);
+
+  public:
+    pipeline(VkDevice device,
+        const std::string &vertShader,
+        const std::string &fragShader);
+    ~pipeline();
+  };
 };
 
 } // namespace nebula


### PR DESCRIPTION
Created new pipeline class; since Vulkan pipelines are nearly 100% immutable, nebula will put all pipeline configuration into a separate object to make switching between pipelines easy. At this point, basic vertex and fragment shader module loading is implemented, though nothing is done with the modules yet.

Note: Shader compilation is not implemented with this PR. This will be done in #56.