### PR TITLE
Increase Code Coverage with mocking of GLFW and Vulkan

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -174,7 +174,7 @@ jobs:
         run: |
           ls /home
           ls /home/runner
-          ls /home/runner/.local
+          mkdir /home/runner/.local
           mkdir /home/runner/.local/share
           test/test
           cd gcov

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -172,6 +172,7 @@ jobs:
       - name: Run tests
         if: matrix.os == 'ubuntu-latest'
         run: |
+          mkdir /home/runner/.local/share
           test/test
           cd gcov
           gcov -o ../test ../src/*.cc -t >test.gcov

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -172,8 +172,6 @@ jobs:
       - name: Run tests
         if: matrix.os == 'ubuntu-latest'
         run: |
-          ls /home
-          ls /home/runner
           mkdir /home/runner/.local
           mkdir /home/runner/.local/share
           test/test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -172,6 +172,9 @@ jobs:
       - name: Run tests
         if: matrix.os == 'ubuntu-latest'
         run: |
+          ls /home
+          ls /home/runner
+          ls /home/runner/.local
           mkdir /home/runner/.local/share
           test/test
           cd gcov

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "external/glfw"]
 	path = external/glfw
 	url = https://github.com/glfw/glfw
+[submodule "external/trompeloeil"]
+	path = external/trompeloeil
+	url = https://github.com/rollbear/trompeloeil

--- a/Tuprules.tup
+++ b/Tuprules.tup
@@ -1,6 +1,5 @@
 
 CFLAGS += -Wall
-CFLAGS += -O2
 CFLAGS += -I../src
 CFLAGS += -I../external/doctest/doctest
 CFLAGS += -I../external/loguru

--- a/Tuprules.tup
+++ b/Tuprules.tup
@@ -18,16 +18,17 @@ CFLAGS += -I../external/glfw/include
 endif
 CFLAGS += -DLOGURU_WITH_STREAMS=1
 ifeq (@(TUP_PLATFORM),win32)
-LDFLAGS += `pkg-config --libs glfw3`
+BUILD_LDFLAGS += `pkg-config --libs glfw3`
 else
-LDFLAGS = -L../external/glfw/src
+BUILD_LDFLAGS = -L../external/glfw/src
 endif
 LDFLAGS += -DLOGURU_WITH_STREAMS=1
 LDFLAGS += -L../external/yaml-cpp
 ifeq (@(TUP_PLATFORM),win32)
-LDFLAGS += -L../VULKAN_SDK/lib -lvulkan-1
+BUILD_LDFLAGS += -L../VULKAN_SDK/lib -lvulkan-1
 else
-LDFLAGS += -lglfw3 -lvulkan -ldl -lpthread -lX11 -lXxf86vm -lXrandr -lXi
+BUILD_LDFLAGS += -lglfw3 -lvulkan
+LDFLAGS += -ldl -lpthread -lX11 -lXxf86vm -lXrandr -lXi
 endif
 LDFLAGS += -lyaml-cpp
 

--- a/build/Tupfile
+++ b/build/Tupfile
@@ -7,12 +7,12 @@ ifeq (@(TUP_PLATFORM),win32)
 : ../external/loguru/loguru.cpp |> !cc -D _WIN32 -I/mingw64/x86_64-w64-mingw32/include |> %B.o
 : ../external/PlatformFolders/sago/platform_folders.cpp |> !cc -D _WIN32 |> %B.o
 : ../external/sqlite-build/sqlite3.c |> !c |> %B.o
-: *.o ../external/lua/liblua.a |> !ld |> nebula.exe
+: *.o ../external/lua/liblua.a |> !ld $(BUILD_LDFLAGS) |> nebula.exe
 else
 : ../external/loguru/loguru.cpp |> !cc |> %B.o
 : ../external/PlatformFolders/sago/platform_folders.cpp |> !cc |> %B.o
 : ../external/sqlite-build/sqlite3.c |> !c |> %B.o
-: *.o ../external/lua/liblua.a |> !ld |> nebula
+: *.o ../external/lua/liblua.a |> !ld $(BUILD_LDFLAGS) |> nebula
 endif
 
 .gitignore

--- a/build/Tupfile
+++ b/build/Tupfile
@@ -1,6 +1,6 @@
 include_rules
 
-CFLAGS += -D DOCTEST_CONFIG_DISABLE
+CFLAGS += -D DOCTEST_CONFIG_DISABLE -O2
 
 : foreach ../src/*.cc ^../src/test.cc |> !cc |> %B.o
 ifeq (@(TUP_PLATFORM),win32)

--- a/src/bind.cc
+++ b/src/bind.cc
@@ -425,6 +425,93 @@ SCENARIO("class bind")
       }
     }
   }
+
+  GIVEN("multiple bind objects mapped to input events")
+  {
+    nebula::bind::modifier modifier;
+    auto bind1 = nebula::bind::create(
+        nullptr, nullptr, nullptr, "Category", "Keyboard Test");
+    auto bind2 = nebula::bind::create(
+        nullptr, nullptr, nullptr, "Category", "Mouse Button Test");
+    auto bind3 = nebula::bind::create(
+        nullptr, nullptr, nullptr, "Category", "Joystick Button Test");
+    auto bind4 = nebula::bind::create(
+        nullptr, nullptr, nullptr, "Category", "Mouse Axis Test");
+    auto bind5 = nebula::bind::create(
+        nullptr, nullptr, nullptr, "Category", "Joystick Axis Test");
+    bind1->bindKey(0, modifier);
+    bind2->bindMButton(0, modifier);
+    bind3->bindJButton(0, 0, modifier);
+    bind4->bindMAxis(0, modifier);
+    bind5->bindJAxis(0, 0, modifier);
+    WHEN("all binds are cleared")
+    {
+      nebula::bind::clearBinds();
+      THEN("none of the binds should be found")
+      {
+        REQUIRE(nebula::bind::findKey(0, modifier) == nullptr);
+        REQUIRE(nebula::bind::findBind("Category", "Keyboard Test") == nullptr);
+        REQUIRE(nebula::bind::findMButton(0, modifier) == nullptr);
+        REQUIRE(
+            nebula::bind::findBind("Category", "Mouse Button Test") == nullptr);
+        REQUIRE(nebula::bind::findJButton(0, 0, modifier) == nullptr);
+        REQUIRE(nebula::bind::findBind("Category", "Joystick Button Test")
+                == nullptr);
+        REQUIRE(nebula::bind::findMAxis(0, modifier) == nullptr);
+        REQUIRE(
+            nebula::bind::findBind("Category", "Mouse Axis Test") == nullptr);
+        REQUIRE(nebula::bind::findJAxis(0, 0, modifier) == nullptr);
+        REQUIRE(nebula::bind::findBind("Category", "Joystick Axis Test")
+                == nullptr);
+      }
+    }
+  }
+
+  GIVEN("multiple bind objects mapped to input events")
+  {
+    nebula::bind::modifier modifier;
+    auto bind1 = nebula::bind::create(
+        nullptr, nullptr, nullptr, "Category", "Keyboard Test");
+    auto bind2 = nebula::bind::create(
+        nullptr, nullptr, nullptr, "Category", "Mouse Button Test");
+    auto bind3 = nebula::bind::create(
+        nullptr, nullptr, nullptr, "Category", "Joystick Button Test");
+    auto bind4 = nebula::bind::create(
+        nullptr, nullptr, nullptr, "Category", "Mouse Axis Test");
+    auto bind5 = nebula::bind::create(
+        nullptr, nullptr, nullptr, "Category", "Joystick Axis Test");
+    bind1->bindKey(0, modifier);
+    bind2->bindMButton(0, modifier);
+    bind3->bindJButton(0, 0, modifier);
+    bind4->bindMAxis(0, modifier);
+    bind5->bindJAxis(0, 0, modifier);
+    WHEN("each event is mapped to new bind objects")
+    {
+      auto bind6 = nebula::bind::create(
+          nullptr, nullptr, nullptr, "Category", "Keyboard Test 2");
+      auto bind7 = nebula::bind::create(
+          nullptr, nullptr, nullptr, "Category", "Mouse Button Test 2");
+      auto bind8 = nebula::bind::create(
+          nullptr, nullptr, nullptr, "Category", "Joystick Button Test 2");
+      auto bind9 = nebula::bind::create(
+          nullptr, nullptr, nullptr, "Category", "Mouse Axis Test 2");
+      auto bind10 = nebula::bind::create(
+          nullptr, nullptr, nullptr, "Category", "Joystick Axis Test 2");
+      bind6->bindKey(0, modifier);
+      bind7->bindMButton(0, modifier);
+      bind8->bindJButton(0, 0, modifier);
+      bind9->bindMAxis(0, modifier);
+      bind10->bindJAxis(0, 0, modifier);
+      THEN("the new binds should be found instead")
+      {
+        REQUIRE(nebula::bind::findKey(0, modifier) == bind6);
+        REQUIRE(nebula::bind::findMButton(0, modifier) == bind7);
+        REQUIRE(nebula::bind::findJButton(0, 0, modifier) == bind8);
+        REQUIRE(nebula::bind::findMAxis(0, modifier) == bind9);
+        REQUIRE(nebula::bind::findJAxis(0, 0, modifier) == bind10);
+      }
+    }
+  }
 }
 #endif
 

--- a/src/ecs.cc
+++ b/src/ecs.cc
@@ -17,7 +17,7 @@ SCENARIO("class ecs")
 {
   GIVEN("an ecs object")
   {
-    nebula::ecs state();
+    REQUIRE_NOTHROW(nebula::ecs state());
   }
 }
 #endif

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -32,7 +32,7 @@ SCENARIO("class engine" * doctest::may_fail())
     // simulate command line arguments
     char argv0[] = "nebula";
     char argv1[] = "-v"; // This and the next option disable logging to stdout
-    char argv2[] = "INFO";
+    char argv2[] = "OFF";
     char *argv[] = {argv0, argv1, argv2, NULL};
 
     nebula::engine testEngine(3, argv);

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -25,10 +25,14 @@ SCENARIO("class engine" * doctest::may_fail())
 {
   GIVEN("an engine object with only command line arguments")
   {
+    // Set up the expectations for this test in a mock object
+    vulkan_mock vkMock;
     vkMock.mockGraphics();
+
+    // simulate command line arguments
     char argv0[] = "nebula";
     char argv1[] = "-v"; // This and the next option disable logging to stdout
-    char argv2[] = "OFF";
+    char argv2[] = "INFO";
     char *argv[] = {argv0, argv1, argv2, NULL};
 
     nebula::engine testEngine(3, argv);
@@ -41,8 +45,6 @@ SCENARIO("class engine" * doctest::may_fail())
       REQUIRE(
           glfwGetWindowAttrib(testEngine.getWindowPointer(), GLFW_DECORATED));
     }
-
-    vkMock.clearExpectations();
   #if 0
     // This is for descriptive purposes only, until this can be coded with a
     // proper test

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -6,9 +6,6 @@
 // Exception includes
 #include "exceptions.h"
 
-// Unit Testing includes
-#include "doctest.h"
-
 // Logging system includes
 #include "loguru.hpp"
 
@@ -20,14 +17,20 @@
 //}
 
 #ifndef DOCTEST_CONFIG_DISABLE
+  #include "doctest.h"
+  #include <doctest/trompeloeil.hpp>
+  #include "../test/vulkan-mock.h"
+
 SCENARIO("class engine" * doctest::may_fail())
 {
   GIVEN("an engine object with only command line arguments")
   {
+    vkMock.mockGraphics();
     char argv0[] = "nebula";
     char argv1[] = "-v"; // This and the next option disable logging to stdout
     char argv2[] = "OFF";
     char *argv[] = {argv0, argv1, argv2, NULL};
+
     nebula::engine testEngine(3, argv);
     THEN("it should have a 1600 x 900 GLFW window with a border")
     {
@@ -39,6 +42,7 @@ SCENARIO("class engine" * doctest::may_fail())
           glfwGetWindowAttrib(testEngine.getWindowPointer(), GLFW_DECORATED));
     }
 
+    vkMock.clearExpectations();
   #if 0
     // This is for descriptive purposes only, until this can be coded with a
     // proper test
@@ -138,7 +142,7 @@ void engine::keyboardEvent(
 void engine::exit()
 {
   LOG_SCOPE_FUNCTION(INFO);
-  glfwSetWindowShouldClose(*_graphics, GLFW_TRUE);
+  _graphics->setClose(true);
 }
 
 void engine::loop()

--- a/src/graphics.cc
+++ b/src/graphics.cc
@@ -24,7 +24,8 @@ SCENARIO("class graphics" * doctest::may_fail())
 {
   GIVEN("a graphics object")
   {
-    // Set up the expectations for this test in the mock object
+    // Set up the expectations for this test in a mock object
+    vulkan_mock vkMock;
     vkMock.mockGraphics();
 
     nebula::graphics gfx(
@@ -33,9 +34,6 @@ SCENARIO("class graphics" * doctest::may_fail())
     {
       REQUIRE_NOTHROW(gfx.drawFrame());
     }
-
-    // Clear all expectations for this test from the mock object
-    vkMock.clearExpectations();
   }
 }
 
@@ -721,7 +719,8 @@ void graphics::logPhysicalDevice()
               << VK_VERSION_MINOR(props.driverVersion) << "."
               << VK_VERSION_PATCH(props.driverVersion);
   LOG_S(INFO) << "vID:dID " << std::hex << std::setw(4) << std::setfill('0')
-              << std::uppercase << (props.vendorID & 0xFFFF) << ":"
+              << std::uppercase << (props.vendorID & 0xFFFF) << ":" << std::hex
+              << std::setw(4) << std::setfill('0') << std::uppercase
               << (props.deviceID & 0xFFFF);
   VkPhysicalDeviceMemoryProperties mem;
   vkGetPhysicalDeviceMemoryProperties(_physicalDevice, &mem);

--- a/src/graphics.cc
+++ b/src/graphics.cc
@@ -15,6 +15,32 @@
 // Logging system includes
 #include "loguru.hpp"
 
+#ifndef DOCTEST_CONFIG_DISABLE
+  #include <doctest.h>
+  #include <doctest/trompeloeil.hpp>
+  #include "../test/vulkan-mock.h"
+
+SCENARIO("class graphics" * doctest::may_fail())
+{
+  GIVEN("a graphics object")
+  {
+    // Set up the expectations for this test in the mock object
+    vkMock.mockGraphics();
+
+    nebula::graphics gfx(
+        1600, 900, [](GLFWwindow *, int, int, int, int) {}, true);
+    THEN("it should not throw when a frame is drawn")
+    {
+      REQUIRE_NOTHROW(gfx.drawFrame());
+    }
+
+    // Clear all expectations for this test from the mock object
+    vkMock.clearExpectations();
+  }
+}
+
+#endif
+
 namespace nebula {
 
 graphics::graphics(uint32_t width,
@@ -114,6 +140,14 @@ void graphics::initGLFW(GLFWkeyfun keyCallback)
   glfwSetWindowUserPointer(_window, this);
   glfwSetFramebufferSizeCallback(_window, framebufferResizeCallback);
   glfwSetKeyCallback(_window, keyCallback);
+}
+
+void graphics::setClose(bool close)
+{
+  if (close)
+    glfwSetWindowShouldClose(_window, GLFW_TRUE);
+  else
+    glfwSetWindowShouldClose(_window, GLFW_FALSE);
 }
 
 void graphics::framebufferResizeCallback(

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -138,6 +138,7 @@ public:
   {
     return _window;
   }
+  void setClose(bool close);
 };
 
 } // namespace nebula

--- a/src/module.cc
+++ b/src/module.cc
@@ -9,6 +9,50 @@
 // Logging system includes
 #include "loguru.hpp"
 
+// Unit Testing includes
+#include "doctest.h"
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+SCENARIO("class module")
+{
+  GIVEN("an invalid module path/module path without manifest")
+  {
+    auto path = "test/invalid";
+    THEN("exception is thrown when creating a module with the path")
+    {
+      REQUIRE_THROWS(nebula::module(path));
+    }
+  }
+  GIVEN("a module with a manifest that lacks a module section")
+  {
+    auto path = "test/no-module-section";
+    THEN("exception is thrown when creating a module with the path")
+    {
+      REQUIRE_THROWS(nebula::module(path));
+    }
+  }
+  GIVEN("a module with a manifest that lacks an identifier")
+  {
+    auto path = "test/no-identifier";
+    THEN("exception is thrown when creating a module with the path")
+    {
+      REQUIRE_THROWS(nebula::module(path));
+    }
+  }
+  GIVEN("a module with a manifest that lacks a name")
+  {
+    auto path = "test/no-name";
+    auto mod  = nebula::module(path);
+    THEN("the name should equal the module's identifier")
+    {
+      REQUIRE(mod.name() == mod.identifier());
+    }
+  }
+}
+
+#endif
+
 #define NEBULA_SEMVER "0.1.0"
 
 namespace nebula {

--- a/src/module.h
+++ b/src/module.h
@@ -30,6 +30,11 @@ public:
     return _identifier;
   }
 
+  const std::string &name() const
+  {
+    return _name;
+  }
+
   const std::vector<std::string> &dependencies() const
   {
     return _dependencies;

--- a/src/module_manager.cc
+++ b/src/module_manager.cc
@@ -118,9 +118,6 @@ void moduleManager::resolveModules()
 void moduleManager::resolveModule(module &mod)
 {
   LOG_SCOPE_FUNCTION(INFO);
-  if (_resolved.find(mod.identifier()) != _resolved.end()) {
-    return;
-  }
   _unresolved.insert(mod.identifier());
   for (auto &dep : mod.dependencies()) {
     LOG_S(INFO) << "Dependency: " << dep;

--- a/src/module_manager.cc
+++ b/src/module_manager.cc
@@ -29,9 +29,7 @@ std::string moduleManager::getModulePaths()
 
 } // namespace nebula
 
-#endif
-
-SCENARIO("class moduleManager" * doctest::may_fail())
+SCENARIO("class moduleManager")
 {
   GIVEN("a moduleManager object")
   {
@@ -46,17 +44,38 @@ SCENARIO("class moduleManager" * doctest::may_fail())
                     + "/samples/asteroids/data"));
       }
     }
+  }
+  GIVEN("a moduleManager object")
+  {
+    nebula::moduleManager modManager;
     WHEN("a local mod path is added")
     {
       modManager.addModulePath("MyGame", true);
       THEN("getModulePaths returns a path relative to the user's game folder")
       {
         REQUIRE(modManager.getModulePaths()
-                == sago::getSaveGamesFolder2() + "/MyGame");
+                == (sago::getSaveGamesFolder2() + "/MyGame"));
+      }
+    }
+  }
+  GIVEN("a moduleManager object")
+  {
+    nebula::moduleManager modManager;
+    WHEN("a mod path with circular dependencies is added and all mods loaded")
+    {
+      modManager.addModulePath("test/circular-deps", false);
+      for (auto &mod : modManager.modules()) {
+        mod.load(true);
+      }
+      THEN("resolveModules should throw an error")
+      {
+        REQUIRE_THROWS(modManager.resolveModules());
       }
     }
   }
 }
+
+#endif
 
 namespace nebula {
 
@@ -77,36 +96,44 @@ void moduleManager::addModulePath(const std::string &path, bool user)
 
 void moduleManager::modPath::loadManifests(moduleManager &manager)
 {
+  LOG_SCOPE_FUNCTION(INFO);
   for (const auto &entry : std::filesystem::directory_iterator(_path))
     if (entry.is_directory()) {
-      manager._modules.emplace_back(entry.path().string());
+      module &m = manager._modules.emplace_back(entry.path().string());
+      manager._moduleMap[m.identifier()] = m;
     }
 }
 
 void moduleManager::resolveModules()
 {
-  std::for_each(_modules.begin(), _modules.end(), [&](auto &mod) {
+  LOG_SCOPE_FUNCTION(INFO);
+  for (auto &mod : _modules) {
+    LOG_S(INFO) << "Module: " << mod.identifier();
     if (mod.load() && _resolved.find(mod.identifier()) == _resolved.end()) {
       resolveModule(mod);
     }
-  });
+  };
 }
 
 void moduleManager::resolveModule(module &mod)
 {
+  LOG_SCOPE_FUNCTION(INFO);
   if (_resolved.find(mod.identifier()) != _resolved.end()) {
     return;
   }
   _unresolved.insert(mod.identifier());
-  std::for_each(
-      mod.dependencies().begin(), mod.dependencies().end(), [&](auto &dep) {
-        if (_resolved.find(dep) == _resolved.end()) {
-          if (_unresolved.find(dep) != _resolved.end()) {
-            throw std::runtime_error("Circular dependency detected!");
-          }
-          resolveModule(_moduleMap.at(dep));
-        }
-      });
+  for (auto &dep : mod.dependencies()) {
+    LOG_S(INFO) << "Dependency: " << dep;
+    if (_resolved.find(dep) == _resolved.end()) {
+      LOG_S(INFO) << "  Dependency not already resolved";
+      if (_unresolved.find(dep) != _unresolved.end()) {
+        LOG_S(ERROR) << "Circular module dependency detected";
+        throw std::runtime_error("Circular module dependency detected");
+      }
+      LOG_S(INFO) << "  No Circular dependency detected, resolving " << dep;
+      resolveModule(_moduleMap[dep]);
+    }
+  };
   _resolved.insert(mod.identifier());
   _unresolved.erase(mod.identifier());
 }

--- a/src/module_manager.h
+++ b/src/module_manager.h
@@ -41,7 +41,10 @@ public:
   ~moduleManager() { }
 
   void addModulePath(const std::string &path, bool user);
-  std::vector<module> &modules();
+  std::vector<module> &modules()
+  {
+    return _modules;
+  }
   void resolveModules();
 
 #ifndef DOCTEST_CONFIG_DISABLE

--- a/test/Tupfile
+++ b/test/Tupfile
@@ -1,12 +1,16 @@
 include_rules
 
+CFLAGS += -I../external/trompeloeil/include
+
 ifeq (@(TUP_PLATFORM),win32)
+: foreach *.cc |> !cc |> %B.o
 : foreach ../src/*.cc ^../src/main.cc |> !cc |> %B.o
 : ../external/loguru/loguru.cpp |> !cc -D _WIN32 -I/mingw64/x86_64-w64-mingw32/include |> %B.o
 : ../external/PlatformFolders/sago/platform_folders.cpp |> !cc -D _WIN32 |> %B.o
 : ../external/sqlite-build/sqlite3.c |> !c |> %B.o
 : *.o ../external/lua/liblua.a |> !ld |> test.exe
 else
+: foreach *.cc |> !cc |> %B.o
 : foreach ../src/*.cc ^../src/main.cc |> !cc -fprofile-arcs -ftest-coverage |> %B.o | %B.gcno
 : ../external/loguru/loguru.cpp |> !cc |> %B.o
 : ../external/PlatformFolders/sago/platform_folders.cpp |> !cc |> %B.o

--- a/test/Tupfile
+++ b/test/Tupfile
@@ -1,6 +1,7 @@
 include_rules
 
 CFLAGS += -I../external/trompeloeil/include
+CFLAGS += -Og
 
 ifeq (@(TUP_PLATFORM),win32)
 : foreach *.cc |> !cc |> %B.o

--- a/test/circular-deps/alpha/manifest.yml
+++ b/test/circular-deps/alpha/manifest.yml
@@ -1,0 +1,9 @@
+module:
+  id: alpha
+  tags: core
+  core: true
+  dependencies:
+  - beta
+  include:
+  - components.yml
+  - systems.yml

--- a/test/circular-deps/beta/manifest.yml
+++ b/test/circular-deps/beta/manifest.yml
@@ -1,0 +1,9 @@
+module:
+  id: beta
+  tags: core
+  core: true
+  dependencies:
+  - alpha
+  include:
+  - components.yml
+  - systems.yml

--- a/test/no-identifier/manifest.yml
+++ b/test/no-identifier/manifest.yml
@@ -1,0 +1,7 @@
+module:
+  name: Game Playing Field
+  tags: core
+  core: true
+  include:
+  - components.yml
+  - systems.yml

--- a/test/no-name/manifest.yml
+++ b/test/no-name/manifest.yml
@@ -1,0 +1,7 @@
+module:
+  id: game-field
+  tags: core
+  core: true
+  include:
+  - components.yml
+  - systems.yml

--- a/test/vulkan-mock.cc
+++ b/test/vulkan-mock.cc
@@ -3,38 +3,48 @@
 #include <doctest/trompeloeil.hpp>
 #include "../test/vulkan-mock.h"
 
+// Logging system includes
+#include "loguru.hpp"
 #include <cstring>
 
 using trompeloeil::_;
-
-vulkan_mock vkMock;
 
 extern "C" {
 
 void glfwSetWindowShouldClose(GLFWwindow *a, int b)
 {
-  vkMock.glfwSetWindowShouldClose(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->glfwSetWindowShouldClose(a, b);
 }
 
 void glfwPollEvents()
 {
-  vkMock.glfwPollEvents();
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->glfwPollEvents();
 }
 
 int glfwWindowShouldClose(GLFWwindow *a)
 {
-  return vkMock.glfwWindowShouldClose(a);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->glfwWindowShouldClose(a);
 }
 
 void glfwGetWindowSize(GLFWwindow *a, int *b, int *c)
 {
-  vkMock.glfwGetWindowSize(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->glfwGetWindowSize(a, b, c);
 }
 
 GLFWwindow *glfwCreateWindow(
     int a, int b, const char *c, GLFWmonitor *d, GLFWwindow *e)
 {
-  return vkMock.glfwCreateWindow(a, b, c, d, e);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->glfwCreateWindow(a, b, c, d, e);
 }
 
 VkResult glfwCreateWindowSurface(VkInstance a,
@@ -42,78 +52,108 @@ VkResult glfwCreateWindowSurface(VkInstance a,
     const VkAllocationCallbacks *c,
     VkSurfaceKHR *d)
 {
-  return vkMock.glfwCreateWindowSurface(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->glfwCreateWindowSurface(a, b, c, d);
 }
 
 void glfwDestroyWindow(GLFWwindow *a)
 {
-  vkMock.glfwDestroyWindow(a);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->glfwDestroyWindow(a);
 }
 
 int glfwGetError(const char **a)
 {
-  return vkMock.glfwGetError(a);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->glfwGetError(a);
 }
 
 void glfwGetFramebufferSize(GLFWwindow *a, int *b, int *c)
 {
-  vkMock.glfwGetFramebufferSize(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->glfwGetFramebufferSize(a, b, c);
 }
 
 const char **glfwGetRequiredInstanceExtensions(uint32_t *a)
 {
-  return vkMock.glfwGetRequiredInstanceExtensions(a);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->glfwGetRequiredInstanceExtensions(a);
 }
 
 const char *glfwGetVersionString()
 {
-  return vkMock.glfwGetVersionString();
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->glfwGetVersionString();
 }
 
 int glfwGetWindowAttrib(GLFWwindow *a, int b)
 {
-  return vkMock.glfwGetWindowAttrib(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->glfwGetWindowAttrib(a, b);
 }
 
 void *glfwGetWindowUserPointer(GLFWwindow *a)
 {
-  return vkMock.glfwGetWindowUserPointer(a);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->glfwGetWindowUserPointer(a);
 }
 
 int glfwInit()
 {
-  return vkMock.glfwInit();
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->glfwInit();
 }
 
 GLFWframebuffersizefun glfwSetFramebufferSizeCallback(
     GLFWwindow *a, GLFWframebuffersizefun b)
 {
-  return vkMock.glfwSetFramebufferSizeCallback(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->glfwSetFramebufferSizeCallback(a, b);
 }
 
 GLFWkeyfun glfwSetKeyCallback(GLFWwindow *a, GLFWkeyfun b)
 {
-  return vkMock.glfwSetKeyCallback(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->glfwSetKeyCallback(a, b);
 }
 
 void glfwSetWindowUserPointer(GLFWwindow *a, void *b)
 {
-  vkMock.glfwSetWindowUserPointer(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->glfwSetWindowUserPointer(a, b);
 }
 
 void glfwTerminate()
 {
-  vkMock.glfwTerminate();
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->glfwTerminate();
 }
 
 void glfwWaitEvents()
 {
-  vkMock.glfwWaitEvents();
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->glfwWaitEvents();
 }
 
 void glfwWindowHint(int a, int b)
 {
-  vkMock.glfwWindowHint(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->glfwWindowHint(a, b);
 }
 
 VkResult vkAcquireNextImageKHR(VkDevice a,
@@ -123,41 +163,55 @@ VkResult vkAcquireNextImageKHR(VkDevice a,
     VkFence e,
     uint32_t *f)
 {
-  return vkMock.vkAcquireNextImageKHR(a, b, c, d, e, f);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkAcquireNextImageKHR(a, b, c, d, e, f);
 }
 
 VkResult vkAllocateCommandBuffers(
     VkDevice a, const VkCommandBufferAllocateInfo *b, VkCommandBuffer *c)
 {
-  return vkMock.vkAllocateCommandBuffers(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkAllocateCommandBuffers(a, b, c);
 }
 
 VkResult vkBeginCommandBuffer(
     VkCommandBuffer a, const VkCommandBufferBeginInfo *b)
 {
-  return vkMock.vkBeginCommandBuffer(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkBeginCommandBuffer(a, b);
 }
 
 void vkCmdBeginRenderPass(
     VkCommandBuffer a, const VkRenderPassBeginInfo *b, VkSubpassContents c)
 {
-  vkMock.vkCmdBeginRenderPass(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkCmdBeginRenderPass(a, b, c);
 }
 
 void vkCmdBindPipeline(VkCommandBuffer a, VkPipelineBindPoint b, VkPipeline c)
 {
-  return vkMock.vkCmdBindPipeline(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCmdBindPipeline(a, b, c);
 }
 
 void vkCmdDraw(
     VkCommandBuffer a, uint32_t b, uint32_t c, uint32_t d, uint32_t e)
 {
-  vkMock.vkCmdDraw(a, b, c, d, e);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkCmdDraw(a, b, c, d, e);
 }
 
 void vkCmdEndRenderPass(VkCommandBuffer a)
 {
-  vkMock.vkCmdEndRenderPass(a);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkCmdEndRenderPass(a);
 }
 
 VkResult vkCreateCommandPool(VkDevice a,
@@ -165,7 +219,9 @@ VkResult vkCreateCommandPool(VkDevice a,
     const VkAllocationCallbacks *c,
     VkCommandPool *d)
 {
-  return vkMock.vkCreateCommandPool(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCreateCommandPool(a, b, c, d);
 }
 
 VkResult vkCreateDevice(VkPhysicalDevice a,
@@ -173,7 +229,9 @@ VkResult vkCreateDevice(VkPhysicalDevice a,
     const VkAllocationCallbacks *c,
     VkDevice *d)
 {
-  return vkMock.vkCreateDevice(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCreateDevice(a, b, c, d);
 }
 
 VkResult vkCreateFence(VkDevice a,
@@ -181,7 +239,9 @@ VkResult vkCreateFence(VkDevice a,
     const VkAllocationCallbacks *c,
     VkFence *d)
 {
-  return vkMock.vkCreateFence(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCreateFence(a, b, c, d);
 }
 
 VkResult vkCreateFramebuffer(VkDevice a,
@@ -189,7 +249,9 @@ VkResult vkCreateFramebuffer(VkDevice a,
     const VkAllocationCallbacks *c,
     VkFramebuffer *d)
 {
-  return vkMock.vkCreateFramebuffer(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCreateFramebuffer(a, b, c, d);
 }
 
 VkResult vkCreateGraphicsPipelines(VkDevice a,
@@ -199,7 +261,9 @@ VkResult vkCreateGraphicsPipelines(VkDevice a,
     const VkAllocationCallbacks *e,
     VkPipeline *f)
 {
-  return vkMock.vkCreateGraphicsPipelines(a, b, c, d, e, f);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCreateGraphicsPipelines(a, b, c, d, e, f);
 }
 
 VkResult vkCreateImageView(VkDevice a,
@@ -207,14 +271,18 @@ VkResult vkCreateImageView(VkDevice a,
     const VkAllocationCallbacks *c,
     VkImageView *d)
 {
-  return vkMock.vkCreateImageView(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCreateImageView(a, b, c, d);
 }
 
 VkResult vkCreateInstance(const VkInstanceCreateInfo *a,
     const VkAllocationCallbacks *b,
     VkInstance *c)
 {
-  return vkMock.vkCreateInstance(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCreateInstance(a, b, c);
 }
 
 VkResult vkCreatePipelineLayout(VkDevice a,
@@ -222,7 +290,9 @@ VkResult vkCreatePipelineLayout(VkDevice a,
     const VkAllocationCallbacks *c,
     VkPipelineLayout *d)
 {
-  return vkMock.vkCreatePipelineLayout(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCreatePipelineLayout(a, b, c, d);
 }
 
 VkResult vkCreateRenderPass(VkDevice a,
@@ -230,7 +300,9 @@ VkResult vkCreateRenderPass(VkDevice a,
     const VkAllocationCallbacks *c,
     VkRenderPass *d)
 {
-  return vkMock.vkCreateRenderPass(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCreateRenderPass(a, b, c, d);
 }
 
 VkResult vkCreateSemaphore(VkDevice a,
@@ -238,7 +310,9 @@ VkResult vkCreateSemaphore(VkDevice a,
     const VkAllocationCallbacks *c,
     VkSemaphore *d)
 {
-  return vkMock.vkCreateSemaphore(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCreateSemaphore(a, b, c, d);
 }
 
 VkResult vkCreateShaderModule(VkDevice a,
@@ -246,7 +320,9 @@ VkResult vkCreateShaderModule(VkDevice a,
     const VkAllocationCallbacks *c,
     VkShaderModule *d)
 {
-  return vkMock.vkCreateShaderModule(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCreateShaderModule(a, b, c, d);
 }
 
 VkResult vkCreateSwapchainKHR(VkDevice a,
@@ -254,193 +330,261 @@ VkResult vkCreateSwapchainKHR(VkDevice a,
     const VkAllocationCallbacks *c,
     VkSwapchainKHR *d)
 {
-  return vkMock.vkCreateSwapchainKHR(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCreateSwapchainKHR(a, b, c, d);
 }
 
 void vkDestroyCommandPool(
     VkDevice a, VkCommandPool b, const VkAllocationCallbacks *c)
 {
-  vkMock.vkDestroyCommandPool(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkDestroyCommandPool(a, b, c);
 }
 
 void vkDestroyDevice(VkDevice a, const VkAllocationCallbacks *b)
 {
-  vkMock.vkDestroyDevice(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkDestroyDevice(a, b);
 }
 
 void vkDestroyFence(VkDevice a, VkFence b, const VkAllocationCallbacks *c)
 {
-  vkMock.vkDestroyFence(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkDestroyFence(a, b, c);
 }
 
 void vkDestroyFramebuffer(
     VkDevice a, VkFramebuffer b, const VkAllocationCallbacks *c)
 {
-  vkMock.vkDestroyFramebuffer(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkDestroyFramebuffer(a, b, c);
 }
 
 void vkDestroyImageView(
     VkDevice a, VkImageView b, const VkAllocationCallbacks *c)
 {
-  vkMock.vkDestroyImageView(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkDestroyImageView(a, b, c);
 }
 
 void vkDestroyInstance(VkInstance a, const VkAllocationCallbacks *b)
 {
-  vkMock.vkDestroyInstance(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkDestroyInstance(a, b);
 }
 
 void vkDestroyPipeline(VkDevice a, VkPipeline b, const VkAllocationCallbacks *c)
 {
-  vkMock.vkDestroyPipeline(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkDestroyPipeline(a, b, c);
 }
 
 void vkDestroyPipelineLayout(
     VkDevice a, VkPipelineLayout b, const VkAllocationCallbacks *c)
 {
-  vkMock.vkDestroyPipelineLayout(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkDestroyPipelineLayout(a, b, c);
 }
 
 void vkDestroyRenderPass(
     VkDevice a, VkRenderPass b, const VkAllocationCallbacks *c)
 {
-  vkMock.vkDestroyRenderPass(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkDestroyRenderPass(a, b, c);
 }
 
 void vkDestroySemaphore(
     VkDevice a, VkSemaphore b, const VkAllocationCallbacks *c)
 {
-  vkMock.vkDestroySemaphore(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkDestroySemaphore(a, b, c);
 }
 
 void vkDestroyShaderModule(
     VkDevice a, VkShaderModule b, const VkAllocationCallbacks *c)
 {
-  vkMock.vkDestroyShaderModule(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkDestroyShaderModule(a, b, c);
 }
 
 void vkDestroySurfaceKHR(
     VkInstance a, VkSurfaceKHR b, const VkAllocationCallbacks *c)
 {
-  vkMock.vkDestroySurfaceKHR(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkDestroySurfaceKHR(a, b, c);
 }
 
 void vkDestroySwapchainKHR(
     VkDevice a, VkSwapchainKHR b, const VkAllocationCallbacks *c)
 {
-  vkMock.vkDestroySwapchainKHR(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkDestroySwapchainKHR(a, b, c);
 }
 
 VkResult vkDeviceWaitIdle(VkDevice a)
 {
-  return vkMock.vkDeviceWaitIdle(a);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkDeviceWaitIdle(a);
 }
 
 VkResult vkEndCommandBuffer(VkCommandBuffer a)
 {
-  return vkMock.vkEndCommandBuffer(a);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkEndCommandBuffer(a);
 }
 
 VkResult vkEnumerateDeviceExtensionProperties(
     VkPhysicalDevice a, const char *b, uint32_t *c, VkExtensionProperties *d)
 {
-  return vkMock.vkEnumerateDeviceExtensionProperties(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkEnumerateDeviceExtensionProperties(a, b, c, d);
 }
 
 VkResult vkEnumerateInstanceLayerProperties(uint32_t *a, VkLayerProperties *b)
 {
-  return vkMock.vkEnumerateInstanceLayerProperties(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkEnumerateInstanceLayerProperties(a, b);
 }
 
 VkResult vkEnumeratePhysicalDevices(
     VkInstance a, uint32_t *b, VkPhysicalDevice *c)
 {
-  return vkMock.vkEnumeratePhysicalDevices(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkEnumeratePhysicalDevices(a, b, c);
 }
 
 void vkFreeCommandBuffers(
     VkDevice a, VkCommandPool b, uint32_t c, const VkCommandBuffer *d)
 {
-  vkMock.vkFreeCommandBuffers(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkFreeCommandBuffers(a, b, c, d);
 }
 
 void vkGetDeviceQueue(VkDevice a, uint32_t b, uint32_t c, VkQueue *d)
 {
-  vkMock.vkGetDeviceQueue(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkGetDeviceQueue(a, b, c, d);
 }
 
 PFN_vkVoidFunction vkGetInstanceProcAddr(VkInstance a, const char *b)
 {
-  return vkMock.vkGetInstanceProcAddr(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkGetInstanceProcAddr(a, b);
 }
 
 void vkGetPhysicalDeviceMemoryProperties(
     VkPhysicalDevice a, VkPhysicalDeviceMemoryProperties *b)
 {
-  vkMock.vkGetPhysicalDeviceMemoryProperties(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkGetPhysicalDeviceMemoryProperties(a, b);
 }
 
 void vkGetPhysicalDeviceProperties(
     VkPhysicalDevice a, VkPhysicalDeviceProperties *b)
 {
-  vkMock.vkGetPhysicalDeviceProperties(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkGetPhysicalDeviceProperties(a, b);
 }
 
 void vkGetPhysicalDeviceQueueFamilyProperties(
     VkPhysicalDevice a, uint32_t *b, VkQueueFamilyProperties *c)
 {
-  vkMock.vkGetPhysicalDeviceQueueFamilyProperties(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  vkMock->vkGetPhysicalDeviceQueueFamilyProperties(a, b, c);
 }
 
 VkResult vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
     VkPhysicalDevice a, VkSurfaceKHR b, VkSurfaceCapabilitiesKHR *c)
 {
-  return vkMock.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkGetPhysicalDeviceSurfaceCapabilitiesKHR(a, b, c);
 }
 
 VkResult vkGetPhysicalDeviceSurfaceFormatsKHR(
     VkPhysicalDevice a, VkSurfaceKHR b, uint32_t *c, VkSurfaceFormatKHR *d)
 {
-  return vkGetPhysicalDeviceSurfaceFormatsKHR(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkGetPhysicalDeviceSurfaceFormatsKHR(a, b, c, d);
 }
 
 VkResult vkGetPhysicalDeviceSurfacePresentModesKHR(
     VkPhysicalDevice a, VkSurfaceKHR b, uint32_t *c, VkPresentModeKHR *d)
 {
-  return vkMock.vkGetPhysicalDeviceSurfacePresentModesKHR(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkGetPhysicalDeviceSurfacePresentModesKHR(a, b, c, d);
 }
 
 VkResult vkGetPhysicalDeviceSurfaceSupportKHR(
     VkPhysicalDevice a, uint32_t b, VkSurfaceKHR c, VkBool32 *d)
 {
-  return vkMock.vkGetPhysicalDeviceSurfaceSupportKHR(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkGetPhysicalDeviceSurfaceSupportKHR(a, b, c, d);
 }
 
 VkResult vkGetSwapchainImagesKHR(
     VkDevice a, VkSwapchainKHR b, uint32_t *c, VkImage *d)
 {
-  return vkMock.vkGetSwapchainImagesKHR(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkGetSwapchainImagesKHR(a, b, c, d);
 }
 
 VkResult vkQueuePresentKHR(VkQueue a, const VkPresentInfoKHR *b)
 {
-  return vkMock.vkQueuePresentKHR(a, b);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkQueuePresentKHR(a, b);
 }
 
 VkResult vkQueueSubmit(VkQueue a, uint32_t b, const VkSubmitInfo *c, VkFence d)
 {
-  return vkMock.vkQueueSubmit(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkQueueSubmit(a, b, c, d);
 }
 
 VkResult vkResetFences(VkDevice a, uint32_t b, const VkFence *c)
 {
-  return vkMock.vkResetFences(a, b, c);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkResetFences(a, b, c);
 }
 
 VkResult vkWaitForFences(
     VkDevice a, uint32_t b, const VkFence *c, VkBool32 d, uint64_t e)
 {
-  return vkMock.vkWaitForFences(a, b, c, d, e);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkWaitForFences(a, b, c, d, e);
 }
 
 VkResult vkCreateDebugUtilsMessengerEXT(VkInstance a,
@@ -448,72 +592,217 @@ VkResult vkCreateDebugUtilsMessengerEXT(VkInstance a,
     const VkAllocationCallbacks *c,
     VkDebugUtilsMessengerEXT *d)
 {
-  return vkMock.vkCreateDebugUtilsMessengerEXT(a, b, c, d);
+  auto vkMock = vulkan_mock::instance();
+  assert(vkMock);
+  return vkMock->vkCreateDebugUtilsMessengerEXT(a, b, c, d);
 }
 }
 
-void vulkan_mock::clearExpectations()
+void vulkan_mock::fillSurfCaps(VkSurfaceCapabilitiesKHR &caps)
 {
-  while (!expectations.empty()) {
-    expectations.pop();
+  LOG_SCOPE_FUNCTION(1);
+  caps.minImageCount           = 1;
+  caps.maxImageCount           = 0;
+  caps.currentExtent.width     = 2560;
+  caps.currentExtent.height    = 1440;
+  caps.minImageExtent.width    = 1;
+  caps.minImageExtent.height   = 1;
+  caps.maxImageExtent.width    = 2560;
+  caps.maxImageExtent.height   = 1440;
+  caps.maxImageArrayLayers     = 1;
+  caps.supportedTransforms     = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+  caps.currentTransform        = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+  caps.supportedCompositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+  caps.supportedUsageFlags     = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+}
+
+void vulkan_mock::fillSurfFmt(VkSurfaceFormatKHR &fmt)
+{
+  fmt.format     = VK_FORMAT_B8G8R8A8_SRGB;
+  fmt.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+}
+
+void vulkan_mock::fillPhysDevProps(VkPhysicalDeviceProperties &props)
+{
+  props.apiVersion    = VK_MAKE_VERSION(1, 2, 155);
+  props.driverVersion = VK_MAKE_VERSION(1, 0, 0);
+  props.vendorID      = 0;
+  props.deviceID      = 0;
+  // Provide a discrete gpu, even though this is a test fixture
+  props.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
+  std::strcpy(props.deviceName, "nebula test device");
+  for (int i = 0; i < VK_UUID_SIZE; i++) {
+    props.pipelineCacheUUID[i] = 0;
+  }
+  // ignoring limits and sparseProperties for now.
+}
+
+void vulkan_mock::fillDevExtProps(VkExtensionProperties &props)
+{
+  std::strcpy(props.extensionName, VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+}
+
+void vulkan_mock::fillPhysDevMemProps(VkPhysicalDeviceMemoryProperties &props)
+{
+  props.memoryTypeCount              = 1;
+  props.memoryHeapCount              = 1;
+  props.memoryTypes[0].propertyFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
+                                     | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
+                                     | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+  props.memoryTypes[0].heapIndex = 0;
+  props.memoryHeaps[0].size      = 8ULL * 1024ULL * 1024ULL * 1024ULL;
+  props.memoryHeaps[0].flags     = VK_MEMORY_HEAP_DEVICE_LOCAL_BIT;
+}
+
+void vulkan_mock::genImgHandles(uint32_t n, VkImage *images)
+{
+  for (uint32_t i = 0; i < n; i++) {
+    images[i] = reinterpret_cast<VkImage>(testImageCur++);
   }
 }
 
 void vulkan_mock::mockGraphics()
 {
-  testWindow         = reinterpret_cast<GLFWwindow *>(400);
-  testVkInstance     = reinterpret_cast<VkInstance>(500);
-  testDUMEXT         = reinterpret_cast<VkDebugUtilsMessengerEXT>(600);
-  testSurface        = reinterpret_cast<VkSurfaceKHR>(700);
+  testWindow         = reinterpret_cast<GLFWwindow *>(0x400);
+  testVkInstance     = reinterpret_cast<VkInstance>(0x500);
+  testDUMEXT         = reinterpret_cast<VkDebugUtilsMessengerEXT>(0x600);
+  testSurface        = reinterpret_cast<VkSurfaceKHR>(0x700);
+  testPhysDev        = reinterpret_cast<VkPhysicalDevice>(0x800);
+  testLogDev         = reinterpret_cast<VkDevice>(0x900);
+  testCombinedQueue  = reinterpret_cast<VkQueue>(0xA00);
+  testSwapChain      = reinterpret_cast<VkSwapchainKHR>(0xB00);
   testSurfaceExt     = "VK_KHR_surface";
   testSurfaceExts[0] = testSurfaceExt;
   testSurfaceExts[1] = nullptr;
   expectations.push(
-      NAMED_ALLOW_CALL(vkMock, glfwGetVersionString()).RETURN("GLFW Mocked"));
-  expectations.push(NAMED_REQUIRE_CALL(vkMock, glfwInit()).RETURN(GLFW_TRUE));
-  expectations.push(NAMED_ALLOW_CALL(vkMock, glfwWindowHint(_, _)));
+      NAMED_ALLOW_CALL(*this, glfwGetVersionString()).RETURN("GLFW Mocked"));
+  expectations.push(NAMED_REQUIRE_CALL(*this, glfwInit()).RETURN(GLFW_TRUE));
+  expectations.push(NAMED_ALLOW_CALL(*this, glfwWindowHint(_, _)));
   expectations.push(
-      NAMED_REQUIRE_CALL(vkMock, glfwCreateWindow(_, _, _, nullptr, nullptr))
+      NAMED_REQUIRE_CALL(*this, glfwCreateWindow(_, _, _, nullptr, nullptr))
           .SIDE_EFFECT(width = _1)
           .SIDE_EFFECT(height = _2)
           .SIDE_EFFECT(title = _3)
           .RETURN(testWindow));
   expectations.push(
-      NAMED_REQUIRE_CALL(vkMock, glfwSetWindowUserPointer(testWindow, _))
+      NAMED_REQUIRE_CALL(*this, glfwSetWindowUserPointer(testWindow, _))
           .LR_SIDE_EFFECT(windowUP = _2));
   expectations.push(
-      NAMED_REQUIRE_CALL(vkMock, glfwSetFramebufferSizeCallback(testWindow, _))
+      NAMED_REQUIRE_CALL(*this, glfwSetFramebufferSizeCallback(testWindow, _))
           .RETURN(nullptr));
+  expectations.push(NAMED_REQUIRE_CALL(*this, glfwSetKeyCallback(testWindow, _))
+                        .RETURN(nullptr));
   expectations.push(
-      NAMED_REQUIRE_CALL(vkMock, glfwSetKeyCallback(testWindow, _))
-          .RETURN(nullptr));
-  expectations.push(
-      NAMED_ALLOW_CALL(vkMock, vkEnumerateInstanceLayerProperties(_, nullptr))
+      NAMED_ALLOW_CALL(*this, vkEnumerateInstanceLayerProperties(_, nullptr))
           .SIDE_EFFECT(*_1 = 1)
           .RETURN(VK_SUCCESS));
   expectations.push(NAMED_ALLOW_CALL(
-      vkMock, vkEnumerateInstanceLayerProperties(_, trompeloeil::ne(nullptr)))
+      *this, vkEnumerateInstanceLayerProperties(_, trompeloeil::ne(nullptr)))
                         .SIDE_EFFECT(std::strcpy(
                             _2->layerName, "VK_LAYER_KHRONOS_validation"))
                         .RETURN(VK_SUCCESS));
   expectations.push(
-      NAMED_ALLOW_CALL(vkMock, glfwGetRequiredInstanceExtensions(_))
+      NAMED_ALLOW_CALL(*this, glfwGetRequiredInstanceExtensions(_))
           .SIDE_EFFECT(*_1 = 1)
           .LR_RETURN((testSurfaceExts)));
-  expectations.push(NAMED_REQUIRE_CALL(vkMock, vkCreateInstance(_, nullptr, _))
+  expectations.push(NAMED_REQUIRE_CALL(*this, vkCreateInstance(_, nullptr, _))
                         .SIDE_EFFECT(*_3 = testVkInstance)
                         .RETURN(VK_SUCCESS));
   expectations.push(
-      NAMED_REQUIRE_CALL(vkMock,
+      NAMED_REQUIRE_CALL(*this,
           vkGetInstanceProcAddr(
               testVkInstance, "vkCreateDebugUtilsMessengerEXT"))
           .RETURN((PFN_vkVoidFunction)(&::vkCreateDebugUtilsMessengerEXT)));
   expectations.push(NAMED_REQUIRE_CALL(
-      vkMock, vkCreateDebugUtilsMessengerEXT(testVkInstance, _, nullptr, _))
+      *this, vkCreateDebugUtilsMessengerEXT(testVkInstance, _, nullptr, _))
                         .SIDE_EFFECT(*_4 = testDUMEXT)
                         .RETURN(VK_SUCCESS));
   expectations.push(NAMED_REQUIRE_CALL(
-      vkMock, glfwCreateWindowSurface(testVkInstance, testWindow, nullptr, _))
+      *this, glfwCreateWindowSurface(testVkInstance, testWindow, nullptr, _))
                         .SIDE_EFFECT(*_4 = testSurface)
                         .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(
+      *this, vkEnumeratePhysicalDevices(testVkInstance, _, nullptr))
+                        .SIDE_EFFECT(*_2 = 1)
+                        .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(*this,
+      vkEnumeratePhysicalDevices(testVkInstance, _, trompeloeil::ne(nullptr)))
+                        .SIDE_EFFECT(*_3 = testPhysDev)
+                        .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(
+      *this, vkGetPhysicalDeviceQueueFamilyProperties(testPhysDev, _, nullptr))
+                        .SIDE_EFFECT(*_2 = 1));
+  expectations.push(NAMED_ALLOW_CALL(*this,
+      vkGetPhysicalDeviceQueueFamilyProperties(
+          testPhysDev, _, trompeloeil::ne(nullptr)))
+                        .SIDE_EFFECT(_3->queueFlags = VK_QUEUE_GRAPHICS_BIT));
+  expectations.push(NAMED_ALLOW_CALL(*this,
+      vkGetPhysicalDeviceSurfaceSupportKHR(testPhysDev, _, testSurface, _))
+                        .SIDE_EFFECT(*_4 = true)
+                        .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(*this,
+      vkGetPhysicalDeviceSurfaceCapabilitiesKHR(testPhysDev, testSurface, _))
+                        .SIDE_EFFECT(fillSurfCaps(*_3))
+                        .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(*this,
+      vkGetPhysicalDeviceSurfaceFormatsKHR(
+          testPhysDev, testSurface, _, nullptr))
+                        .SIDE_EFFECT(*_3 = 1)
+                        .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(*this,
+      vkGetPhysicalDeviceSurfaceFormatsKHR(
+          testPhysDev, testSurface, _, trompeloeil::ne(nullptr)))
+                        .SIDE_EFFECT(fillSurfFmt(*_4))
+                        .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(*this,
+      vkGetPhysicalDeviceSurfacePresentModesKHR(
+          testPhysDev, testSurface, _, nullptr))
+                        .SIDE_EFFECT(*_3 = 1)
+                        .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(*this,
+      vkGetPhysicalDeviceSurfacePresentModesKHR(
+          testPhysDev, testSurface, _, trompeloeil::ne(nullptr)))
+                        .SIDE_EFFECT(*_4 = VK_PRESENT_MODE_FIFO_KHR)
+                        .RETURN(VK_SUCCESS));
+  expectations.push(
+      NAMED_ALLOW_CALL(*this, vkGetPhysicalDeviceProperties(testPhysDev, _))
+          .SIDE_EFFECT(fillPhysDevProps(*_2)));
+  expectations.push(NAMED_ALLOW_CALL(*this,
+      vkEnumerateDeviceExtensionProperties(testPhysDev, nullptr, _, nullptr))
+                        .SIDE_EFFECT(*_3 = 1)
+                        .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(*this,
+      vkEnumerateDeviceExtensionProperties(
+          testPhysDev, nullptr, _, trompeloeil::ne(nullptr)))
+                        .SIDE_EFFECT(fillDevExtProps(*_4))
+                        .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(
+      *this, vkGetPhysicalDeviceMemoryProperties(testPhysDev, _))
+                        .SIDE_EFFECT(fillPhysDevMemProps(*_2)));
+  expectations.push(
+      NAMED_ALLOW_CALL(*this, vkCreateDevice(testPhysDev, _, nullptr, _))
+          .SIDE_EFFECT(*_4 = testLogDev)
+          .RETURN(VK_SUCCESS));
+  expectations.push(
+      NAMED_ALLOW_CALL(*this, vkGetDeviceQueue(testLogDev, 0u, 0u, _))
+          .SIDE_EFFECT(*_4 = testCombinedQueue));
+  expectations.push(
+      NAMED_ALLOW_CALL(*this, vkCreateSwapchainKHR(testLogDev, _, nullptr, _))
+          .SIDE_EFFECT(testSwapChainImageCount = _2->minImageCount)
+          .SIDE_EFFECT(*_4 = testSwapChain)
+          .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(
+      *this, vkGetSwapchainImagesKHR(testLogDev, testSwapChain, _, nullptr))
+                        .SIDE_EFFECT(*_3 = testSwapChainImageCount)
+                        .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(*this,
+      vkGetSwapchainImagesKHR(
+          testLogDev, testSwapChain, _, trompeloeil::ne(nullptr)))
+                        .SIDE_EFFECT(genImgHandles(testSwapChainImageCount, _4))
+                        .RETURN(VK_SUCCESS));
+  expectations.push(
+      NAMED_ALLOW_CALL(*this,
+          vkCreateImageView(testLogDev, _, nullptr, trompeloeil::ne(nullptr)))
+          .SIDE_EFFECT(*_4 = reinterpret_cast<VkImageView>(_2->image))
+          .RETURN(VK_SUCCESS));
 }

--- a/test/vulkan-mock.cc
+++ b/test/vulkan-mock.cc
@@ -1,0 +1,519 @@
+
+#include <doctest.h>
+#include <doctest/trompeloeil.hpp>
+#include "../test/vulkan-mock.h"
+
+#include <cstring>
+
+using trompeloeil::_;
+
+vulkan_mock vkMock;
+
+extern "C" {
+
+void glfwSetWindowShouldClose(GLFWwindow *a, int b)
+{
+  vkMock.glfwSetWindowShouldClose(a, b);
+}
+
+void glfwPollEvents()
+{
+  vkMock.glfwPollEvents();
+}
+
+int glfwWindowShouldClose(GLFWwindow *a)
+{
+  return vkMock.glfwWindowShouldClose(a);
+}
+
+void glfwGetWindowSize(GLFWwindow *a, int *b, int *c)
+{
+  vkMock.glfwGetWindowSize(a, b, c);
+}
+
+GLFWwindow *glfwCreateWindow(
+    int a, int b, const char *c, GLFWmonitor *d, GLFWwindow *e)
+{
+  return vkMock.glfwCreateWindow(a, b, c, d, e);
+}
+
+VkResult glfwCreateWindowSurface(VkInstance a,
+    GLFWwindow *b,
+    const VkAllocationCallbacks *c,
+    VkSurfaceKHR *d)
+{
+  return vkMock.glfwCreateWindowSurface(a, b, c, d);
+}
+
+void glfwDestroyWindow(GLFWwindow *a)
+{
+  vkMock.glfwDestroyWindow(a);
+}
+
+int glfwGetError(const char **a)
+{
+  return vkMock.glfwGetError(a);
+}
+
+void glfwGetFramebufferSize(GLFWwindow *a, int *b, int *c)
+{
+  vkMock.glfwGetFramebufferSize(a, b, c);
+}
+
+const char **glfwGetRequiredInstanceExtensions(uint32_t *a)
+{
+  return vkMock.glfwGetRequiredInstanceExtensions(a);
+}
+
+const char *glfwGetVersionString()
+{
+  return vkMock.glfwGetVersionString();
+}
+
+int glfwGetWindowAttrib(GLFWwindow *a, int b)
+{
+  return vkMock.glfwGetWindowAttrib(a, b);
+}
+
+void *glfwGetWindowUserPointer(GLFWwindow *a)
+{
+  return vkMock.glfwGetWindowUserPointer(a);
+}
+
+int glfwInit()
+{
+  return vkMock.glfwInit();
+}
+
+GLFWframebuffersizefun glfwSetFramebufferSizeCallback(
+    GLFWwindow *a, GLFWframebuffersizefun b)
+{
+  return vkMock.glfwSetFramebufferSizeCallback(a, b);
+}
+
+GLFWkeyfun glfwSetKeyCallback(GLFWwindow *a, GLFWkeyfun b)
+{
+  return vkMock.glfwSetKeyCallback(a, b);
+}
+
+void glfwSetWindowUserPointer(GLFWwindow *a, void *b)
+{
+  vkMock.glfwSetWindowUserPointer(a, b);
+}
+
+void glfwTerminate()
+{
+  vkMock.glfwTerminate();
+}
+
+void glfwWaitEvents()
+{
+  vkMock.glfwWaitEvents();
+}
+
+void glfwWindowHint(int a, int b)
+{
+  vkMock.glfwWindowHint(a, b);
+}
+
+VkResult vkAcquireNextImageKHR(VkDevice a,
+    VkSwapchainKHR b,
+    uint64_t c,
+    VkSemaphore d,
+    VkFence e,
+    uint32_t *f)
+{
+  return vkMock.vkAcquireNextImageKHR(a, b, c, d, e, f);
+}
+
+VkResult vkAllocateCommandBuffers(
+    VkDevice a, const VkCommandBufferAllocateInfo *b, VkCommandBuffer *c)
+{
+  return vkMock.vkAllocateCommandBuffers(a, b, c);
+}
+
+VkResult vkBeginCommandBuffer(
+    VkCommandBuffer a, const VkCommandBufferBeginInfo *b)
+{
+  return vkMock.vkBeginCommandBuffer(a, b);
+}
+
+void vkCmdBeginRenderPass(
+    VkCommandBuffer a, const VkRenderPassBeginInfo *b, VkSubpassContents c)
+{
+  vkMock.vkCmdBeginRenderPass(a, b, c);
+}
+
+void vkCmdBindPipeline(VkCommandBuffer a, VkPipelineBindPoint b, VkPipeline c)
+{
+  return vkMock.vkCmdBindPipeline(a, b, c);
+}
+
+void vkCmdDraw(
+    VkCommandBuffer a, uint32_t b, uint32_t c, uint32_t d, uint32_t e)
+{
+  vkMock.vkCmdDraw(a, b, c, d, e);
+}
+
+void vkCmdEndRenderPass(VkCommandBuffer a)
+{
+  vkMock.vkCmdEndRenderPass(a);
+}
+
+VkResult vkCreateCommandPool(VkDevice a,
+    const VkCommandPoolCreateInfo *b,
+    const VkAllocationCallbacks *c,
+    VkCommandPool *d)
+{
+  return vkMock.vkCreateCommandPool(a, b, c, d);
+}
+
+VkResult vkCreateDevice(VkPhysicalDevice a,
+    const VkDeviceCreateInfo *b,
+    const VkAllocationCallbacks *c,
+    VkDevice *d)
+{
+  return vkMock.vkCreateDevice(a, b, c, d);
+}
+
+VkResult vkCreateFence(VkDevice a,
+    const VkFenceCreateInfo *b,
+    const VkAllocationCallbacks *c,
+    VkFence *d)
+{
+  return vkMock.vkCreateFence(a, b, c, d);
+}
+
+VkResult vkCreateFramebuffer(VkDevice a,
+    const VkFramebufferCreateInfo *b,
+    const VkAllocationCallbacks *c,
+    VkFramebuffer *d)
+{
+  return vkMock.vkCreateFramebuffer(a, b, c, d);
+}
+
+VkResult vkCreateGraphicsPipelines(VkDevice a,
+    VkPipelineCache b,
+    uint32_t c,
+    const VkGraphicsPipelineCreateInfo *d,
+    const VkAllocationCallbacks *e,
+    VkPipeline *f)
+{
+  return vkMock.vkCreateGraphicsPipelines(a, b, c, d, e, f);
+}
+
+VkResult vkCreateImageView(VkDevice a,
+    const VkImageViewCreateInfo *b,
+    const VkAllocationCallbacks *c,
+    VkImageView *d)
+{
+  return vkMock.vkCreateImageView(a, b, c, d);
+}
+
+VkResult vkCreateInstance(const VkInstanceCreateInfo *a,
+    const VkAllocationCallbacks *b,
+    VkInstance *c)
+{
+  return vkMock.vkCreateInstance(a, b, c);
+}
+
+VkResult vkCreatePipelineLayout(VkDevice a,
+    const VkPipelineLayoutCreateInfo *b,
+    const VkAllocationCallbacks *c,
+    VkPipelineLayout *d)
+{
+  return vkMock.vkCreatePipelineLayout(a, b, c, d);
+}
+
+VkResult vkCreateRenderPass(VkDevice a,
+    const VkRenderPassCreateInfo *b,
+    const VkAllocationCallbacks *c,
+    VkRenderPass *d)
+{
+  return vkMock.vkCreateRenderPass(a, b, c, d);
+}
+
+VkResult vkCreateSemaphore(VkDevice a,
+    const VkSemaphoreCreateInfo *b,
+    const VkAllocationCallbacks *c,
+    VkSemaphore *d)
+{
+  return vkMock.vkCreateSemaphore(a, b, c, d);
+}
+
+VkResult vkCreateShaderModule(VkDevice a,
+    const VkShaderModuleCreateInfo *b,
+    const VkAllocationCallbacks *c,
+    VkShaderModule *d)
+{
+  return vkMock.vkCreateShaderModule(a, b, c, d);
+}
+
+VkResult vkCreateSwapchainKHR(VkDevice a,
+    const VkSwapchainCreateInfoKHR *b,
+    const VkAllocationCallbacks *c,
+    VkSwapchainKHR *d)
+{
+  return vkMock.vkCreateSwapchainKHR(a, b, c, d);
+}
+
+void vkDestroyCommandPool(
+    VkDevice a, VkCommandPool b, const VkAllocationCallbacks *c)
+{
+  vkMock.vkDestroyCommandPool(a, b, c);
+}
+
+void vkDestroyDevice(VkDevice a, const VkAllocationCallbacks *b)
+{
+  vkMock.vkDestroyDevice(a, b);
+}
+
+void vkDestroyFence(VkDevice a, VkFence b, const VkAllocationCallbacks *c)
+{
+  vkMock.vkDestroyFence(a, b, c);
+}
+
+void vkDestroyFramebuffer(
+    VkDevice a, VkFramebuffer b, const VkAllocationCallbacks *c)
+{
+  vkMock.vkDestroyFramebuffer(a, b, c);
+}
+
+void vkDestroyImageView(
+    VkDevice a, VkImageView b, const VkAllocationCallbacks *c)
+{
+  vkMock.vkDestroyImageView(a, b, c);
+}
+
+void vkDestroyInstance(VkInstance a, const VkAllocationCallbacks *b)
+{
+  vkMock.vkDestroyInstance(a, b);
+}
+
+void vkDestroyPipeline(VkDevice a, VkPipeline b, const VkAllocationCallbacks *c)
+{
+  vkMock.vkDestroyPipeline(a, b, c);
+}
+
+void vkDestroyPipelineLayout(
+    VkDevice a, VkPipelineLayout b, const VkAllocationCallbacks *c)
+{
+  vkMock.vkDestroyPipelineLayout(a, b, c);
+}
+
+void vkDestroyRenderPass(
+    VkDevice a, VkRenderPass b, const VkAllocationCallbacks *c)
+{
+  vkMock.vkDestroyRenderPass(a, b, c);
+}
+
+void vkDestroySemaphore(
+    VkDevice a, VkSemaphore b, const VkAllocationCallbacks *c)
+{
+  vkMock.vkDestroySemaphore(a, b, c);
+}
+
+void vkDestroyShaderModule(
+    VkDevice a, VkShaderModule b, const VkAllocationCallbacks *c)
+{
+  vkMock.vkDestroyShaderModule(a, b, c);
+}
+
+void vkDestroySurfaceKHR(
+    VkInstance a, VkSurfaceKHR b, const VkAllocationCallbacks *c)
+{
+  vkMock.vkDestroySurfaceKHR(a, b, c);
+}
+
+void vkDestroySwapchainKHR(
+    VkDevice a, VkSwapchainKHR b, const VkAllocationCallbacks *c)
+{
+  vkMock.vkDestroySwapchainKHR(a, b, c);
+}
+
+VkResult vkDeviceWaitIdle(VkDevice a)
+{
+  return vkMock.vkDeviceWaitIdle(a);
+}
+
+VkResult vkEndCommandBuffer(VkCommandBuffer a)
+{
+  return vkMock.vkEndCommandBuffer(a);
+}
+
+VkResult vkEnumerateDeviceExtensionProperties(
+    VkPhysicalDevice a, const char *b, uint32_t *c, VkExtensionProperties *d)
+{
+  return vkMock.vkEnumerateDeviceExtensionProperties(a, b, c, d);
+}
+
+VkResult vkEnumerateInstanceLayerProperties(uint32_t *a, VkLayerProperties *b)
+{
+  return vkMock.vkEnumerateInstanceLayerProperties(a, b);
+}
+
+VkResult vkEnumeratePhysicalDevices(
+    VkInstance a, uint32_t *b, VkPhysicalDevice *c)
+{
+  return vkMock.vkEnumeratePhysicalDevices(a, b, c);
+}
+
+void vkFreeCommandBuffers(
+    VkDevice a, VkCommandPool b, uint32_t c, const VkCommandBuffer *d)
+{
+  vkMock.vkFreeCommandBuffers(a, b, c, d);
+}
+
+void vkGetDeviceQueue(VkDevice a, uint32_t b, uint32_t c, VkQueue *d)
+{
+  vkMock.vkGetDeviceQueue(a, b, c, d);
+}
+
+PFN_vkVoidFunction vkGetInstanceProcAddr(VkInstance a, const char *b)
+{
+  return vkMock.vkGetInstanceProcAddr(a, b);
+}
+
+void vkGetPhysicalDeviceMemoryProperties(
+    VkPhysicalDevice a, VkPhysicalDeviceMemoryProperties *b)
+{
+  vkMock.vkGetPhysicalDeviceMemoryProperties(a, b);
+}
+
+void vkGetPhysicalDeviceProperties(
+    VkPhysicalDevice a, VkPhysicalDeviceProperties *b)
+{
+  vkMock.vkGetPhysicalDeviceProperties(a, b);
+}
+
+void vkGetPhysicalDeviceQueueFamilyProperties(
+    VkPhysicalDevice a, uint32_t *b, VkQueueFamilyProperties *c)
+{
+  vkMock.vkGetPhysicalDeviceQueueFamilyProperties(a, b, c);
+}
+
+VkResult vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+    VkPhysicalDevice a, VkSurfaceKHR b, VkSurfaceCapabilitiesKHR *c)
+{
+  return vkMock.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(a, b, c);
+}
+
+VkResult vkGetPhysicalDeviceSurfaceFormatsKHR(
+    VkPhysicalDevice a, VkSurfaceKHR b, uint32_t *c, VkSurfaceFormatKHR *d)
+{
+  return vkGetPhysicalDeviceSurfaceFormatsKHR(a, b, c, d);
+}
+
+VkResult vkGetPhysicalDeviceSurfacePresentModesKHR(
+    VkPhysicalDevice a, VkSurfaceKHR b, uint32_t *c, VkPresentModeKHR *d)
+{
+  return vkMock.vkGetPhysicalDeviceSurfacePresentModesKHR(a, b, c, d);
+}
+
+VkResult vkGetPhysicalDeviceSurfaceSupportKHR(
+    VkPhysicalDevice a, uint32_t b, VkSurfaceKHR c, VkBool32 *d)
+{
+  return vkMock.vkGetPhysicalDeviceSurfaceSupportKHR(a, b, c, d);
+}
+
+VkResult vkGetSwapchainImagesKHR(
+    VkDevice a, VkSwapchainKHR b, uint32_t *c, VkImage *d)
+{
+  return vkMock.vkGetSwapchainImagesKHR(a, b, c, d);
+}
+
+VkResult vkQueuePresentKHR(VkQueue a, const VkPresentInfoKHR *b)
+{
+  return vkMock.vkQueuePresentKHR(a, b);
+}
+
+VkResult vkQueueSubmit(VkQueue a, uint32_t b, const VkSubmitInfo *c, VkFence d)
+{
+  return vkMock.vkQueueSubmit(a, b, c, d);
+}
+
+VkResult vkResetFences(VkDevice a, uint32_t b, const VkFence *c)
+{
+  return vkMock.vkResetFences(a, b, c);
+}
+
+VkResult vkWaitForFences(
+    VkDevice a, uint32_t b, const VkFence *c, VkBool32 d, uint64_t e)
+{
+  return vkMock.vkWaitForFences(a, b, c, d, e);
+}
+
+VkResult vkCreateDebugUtilsMessengerEXT(VkInstance a,
+    const VkDebugUtilsMessengerCreateInfoEXT *b,
+    const VkAllocationCallbacks *c,
+    VkDebugUtilsMessengerEXT *d)
+{
+  return vkMock.vkCreateDebugUtilsMessengerEXT(a, b, c, d);
+}
+}
+
+void vulkan_mock::clearExpectations()
+{
+  while (!expectations.empty()) {
+    expectations.pop();
+  }
+}
+
+void vulkan_mock::mockGraphics()
+{
+  testWindow         = reinterpret_cast<GLFWwindow *>(400);
+  testVkInstance     = reinterpret_cast<VkInstance>(500);
+  testDUMEXT         = reinterpret_cast<VkDebugUtilsMessengerEXT>(600);
+  testSurface        = reinterpret_cast<VkSurfaceKHR>(700);
+  testSurfaceExt     = "VK_KHR_surface";
+  testSurfaceExts[0] = testSurfaceExt;
+  testSurfaceExts[1] = nullptr;
+  expectations.push(
+      NAMED_ALLOW_CALL(vkMock, glfwGetVersionString()).RETURN("GLFW Mocked"));
+  expectations.push(NAMED_REQUIRE_CALL(vkMock, glfwInit()).RETURN(GLFW_TRUE));
+  expectations.push(NAMED_ALLOW_CALL(vkMock, glfwWindowHint(_, _)));
+  expectations.push(
+      NAMED_REQUIRE_CALL(vkMock, glfwCreateWindow(_, _, _, nullptr, nullptr))
+          .SIDE_EFFECT(width = _1)
+          .SIDE_EFFECT(height = _2)
+          .SIDE_EFFECT(title = _3)
+          .RETURN(testWindow));
+  expectations.push(
+      NAMED_REQUIRE_CALL(vkMock, glfwSetWindowUserPointer(testWindow, _))
+          .LR_SIDE_EFFECT(windowUP = _2));
+  expectations.push(
+      NAMED_REQUIRE_CALL(vkMock, glfwSetFramebufferSizeCallback(testWindow, _))
+          .RETURN(nullptr));
+  expectations.push(
+      NAMED_REQUIRE_CALL(vkMock, glfwSetKeyCallback(testWindow, _))
+          .RETURN(nullptr));
+  expectations.push(
+      NAMED_ALLOW_CALL(vkMock, vkEnumerateInstanceLayerProperties(_, nullptr))
+          .SIDE_EFFECT(*_1 = 1)
+          .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(
+      vkMock, vkEnumerateInstanceLayerProperties(_, trompeloeil::ne(nullptr)))
+                        .SIDE_EFFECT(std::strcpy(
+                            _2->layerName, "VK_LAYER_KHRONOS_validation"))
+                        .RETURN(VK_SUCCESS));
+  expectations.push(
+      NAMED_ALLOW_CALL(vkMock, glfwGetRequiredInstanceExtensions(_))
+          .SIDE_EFFECT(*_1 = 1)
+          .LR_RETURN((testSurfaceExts)));
+  expectations.push(NAMED_REQUIRE_CALL(vkMock, vkCreateInstance(_, nullptr, _))
+                        .SIDE_EFFECT(*_3 = testVkInstance)
+                        .RETURN(VK_SUCCESS));
+  expectations.push(
+      NAMED_REQUIRE_CALL(vkMock,
+          vkGetInstanceProcAddr(
+              testVkInstance, "vkCreateDebugUtilsMessengerEXT"))
+          .RETURN((PFN_vkVoidFunction)(&::vkCreateDebugUtilsMessengerEXT)));
+  expectations.push(NAMED_REQUIRE_CALL(
+      vkMock, vkCreateDebugUtilsMessengerEXT(testVkInstance, _, nullptr, _))
+                        .SIDE_EFFECT(*_4 = testDUMEXT)
+                        .RETURN(VK_SUCCESS));
+  expectations.push(NAMED_REQUIRE_CALL(
+      vkMock, glfwCreateWindowSurface(testVkInstance, testWindow, nullptr, _))
+                        .SIDE_EFFECT(*_4 = testSurface)
+                        .RETURN(VK_SUCCESS));
+}

--- a/test/vulkan-mock.h
+++ b/test/vulkan-mock.h
@@ -1,0 +1,208 @@
+// This document is licensed according to the LGPL v2.1 license
+// Consult the LICENSE file in the root project directory for details
+
+#ifndef NEBULA_TEST_VULKAN_MOCK_H
+#define NEBULA_TEST_VULKAN_MOCK_H
+
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+
+#include <string>
+
+class vulkan_mock {
+private:
+  GLFWwindow *testWindow;
+  VkInstance testVkInstance;
+  VkDebugUtilsMessengerEXT testDUMEXT;
+  VkSurfaceKHR testSurface;
+  const char *testSurfaceExt;
+  const char *testSurfaceExts[2];
+  void *windowUP = nullptr;
+  std::stack<std::unique_ptr<trompeloeil::expectation>> expectations;
+  int width;
+  int height;
+  std::string title;
+
+public:
+  void clearExpectations();
+  void mockGraphics();
+
+  MAKE_MOCK2(glfwSetWindowShouldClose, void(GLFWwindow *, int));
+  MAKE_MOCK0(glfwPollEvents, void());
+  MAKE_MOCK1(glfwWindowShouldClose, int(GLFWwindow *));
+  MAKE_MOCK3(glfwGetWindowSize, void(GLFWwindow *, int *, int *));
+  MAKE_MOCK5(glfwCreateWindow,
+      GLFWwindow *(int, int, const char *, GLFWmonitor *, GLFWwindow *));
+  MAKE_MOCK4(glfwCreateWindowSurface,
+      VkResult(VkInstance,
+          GLFWwindow *,
+          const VkAllocationCallbacks *,
+          VkSurfaceKHR *));
+  MAKE_MOCK1(glfwDestroyWindow, void(GLFWwindow *));
+  MAKE_MOCK1(glfwGetError, int(const char **));
+  MAKE_MOCK3(glfwGetFramebufferSize, void(GLFWwindow *, int *, int *));
+  MAKE_MOCK1(glfwGetRequiredInstanceExtensions, const char **(uint32_t *));
+  MAKE_MOCK0(glfwGetVersionString, const char *());
+  MAKE_MOCK2(glfwGetWindowAttrib, int(GLFWwindow *, int));
+  MAKE_MOCK1(glfwGetWindowUserPointer, void *(GLFWwindow *));
+  MAKE_MOCK0(glfwInit, int());
+  MAKE_MOCK2(glfwSetFramebufferSizeCallback,
+      GLFWframebuffersizefun(GLFWwindow *, GLFWframebuffersizefun));
+  MAKE_MOCK2(glfwSetKeyCallback, GLFWkeyfun(GLFWwindow *, GLFWkeyfun));
+  MAKE_MOCK2(glfwSetWindowUserPointer, void(GLFWwindow *, void *));
+  MAKE_MOCK0(glfwTerminate, void());
+  MAKE_MOCK0(glfwWaitEvents, void());
+  MAKE_MOCK2(glfwWindowHint, void(int, int));
+  MAKE_MOCK6(vkAcquireNextImageKHR,
+      VkResult(VkDevice,
+          VkSwapchainKHR,
+          uint64_t,
+          VkSemaphore,
+          VkFence,
+          uint32_t *f));
+  MAKE_MOCK3(vkAllocateCommandBuffers,
+      VkResult(
+          VkDevice, const VkCommandBufferAllocateInfo *, VkCommandBuffer *));
+  MAKE_MOCK2(vkBeginCommandBuffer,
+      VkResult(VkCommandBuffer, const VkCommandBufferBeginInfo *));
+  MAKE_MOCK3(vkCmdBeginRenderPass,
+      void(VkCommandBuffer, const VkRenderPassBeginInfo *, VkSubpassContents));
+  MAKE_MOCK3(vkCmdBindPipeline,
+      void(VkCommandBuffer, VkPipelineBindPoint, VkPipeline));
+  MAKE_MOCK5(
+      vkCmdDraw, void(VkCommandBuffer, uint32_t, uint32_t, uint32_t, uint32_t));
+  MAKE_MOCK1(vkCmdEndRenderPass, void(VkCommandBuffer));
+  MAKE_MOCK4(vkCreateCommandPool,
+      VkResult(VkDevice,
+          const VkCommandPoolCreateInfo *,
+          const VkAllocationCallbacks *,
+          VkCommandPool *));
+  MAKE_MOCK4(vkCreateDevice,
+      VkResult(VkPhysicalDevice,
+          const VkDeviceCreateInfo *,
+          const VkAllocationCallbacks *,
+          VkDevice *));
+  MAKE_MOCK4(vkCreateFence,
+      VkResult(VkDevice,
+          const VkFenceCreateInfo *,
+          const VkAllocationCallbacks *,
+          VkFence *));
+  MAKE_MOCK4(vkCreateFramebuffer,
+      VkResult(VkDevice,
+          const VkFramebufferCreateInfo *,
+          const VkAllocationCallbacks *,
+          VkFramebuffer *));
+  MAKE_MOCK6(vkCreateGraphicsPipelines,
+      VkResult(VkDevice,
+          VkPipelineCache,
+          uint32_t,
+          const VkGraphicsPipelineCreateInfo *,
+          const VkAllocationCallbacks *,
+          VkPipeline *));
+  MAKE_MOCK4(vkCreateImageView,
+      VkResult(VkDevice,
+          const VkImageViewCreateInfo *,
+          const VkAllocationCallbacks *,
+          VkImageView *));
+  MAKE_MOCK3(vkCreateInstance,
+      VkResult(const VkInstanceCreateInfo *,
+          const VkAllocationCallbacks *,
+          VkInstance *));
+  MAKE_MOCK4(vkCreatePipelineLayout,
+      VkResult(VkDevice,
+          const VkPipelineLayoutCreateInfo *,
+          const VkAllocationCallbacks *,
+          VkPipelineLayout *));
+  MAKE_MOCK4(vkCreateRenderPass,
+      VkResult(VkDevice,
+          const VkRenderPassCreateInfo *,
+          const VkAllocationCallbacks *,
+          VkRenderPass *));
+  MAKE_MOCK4(vkCreateSemaphore,
+      VkResult(VkDevice,
+          const VkSemaphoreCreateInfo *,
+          const VkAllocationCallbacks *,
+          VkSemaphore *));
+  MAKE_MOCK4(vkCreateShaderModule,
+      VkResult(VkDevice,
+          const VkShaderModuleCreateInfo *,
+          const VkAllocationCallbacks *,
+          VkShaderModule *));
+  MAKE_MOCK4(vkCreateSwapchainKHR,
+      VkResult(VkDevice,
+          const VkSwapchainCreateInfoKHR *,
+          const VkAllocationCallbacks *,
+          VkSwapchainKHR *));
+  MAKE_MOCK3(vkDestroyCommandPool,
+      void(VkDevice, VkCommandPool, const VkAllocationCallbacks *));
+  MAKE_MOCK2(vkDestroyDevice, void(VkDevice, const VkAllocationCallbacks *));
+  MAKE_MOCK3(
+      vkDestroyFence, void(VkDevice, VkFence, const VkAllocationCallbacks *));
+  MAKE_MOCK3(vkDestroyFramebuffer,
+      void(VkDevice, VkFramebuffer, const VkAllocationCallbacks *));
+  MAKE_MOCK3(vkDestroyImageView,
+      void(VkDevice, VkImageView, const VkAllocationCallbacks *));
+  MAKE_MOCK2(
+      vkDestroyInstance, void(VkInstance, const VkAllocationCallbacks *));
+  MAKE_MOCK3(vkDestroyPipeline,
+      void(VkDevice, VkPipeline, const VkAllocationCallbacks *));
+  MAKE_MOCK3(vkDestroyPipelineLayout,
+      void(VkDevice, VkPipelineLayout, const VkAllocationCallbacks *));
+  MAKE_MOCK3(vkDestroyRenderPass,
+      void(VkDevice, VkRenderPass, const VkAllocationCallbacks *));
+  MAKE_MOCK3(vkDestroySemaphore,
+      void(VkDevice, VkSemaphore, const VkAllocationCallbacks *));
+  MAKE_MOCK3(vkDestroyShaderModule,
+      void(VkDevice, VkShaderModule, const VkAllocationCallbacks *));
+  MAKE_MOCK3(vkDestroySurfaceKHR,
+      void(VkInstance, VkSurfaceKHR, const VkAllocationCallbacks *));
+  MAKE_MOCK3(vkDestroySwapchainKHR,
+      void(VkDevice, VkSwapchainKHR, const VkAllocationCallbacks *));
+  MAKE_MOCK1(vkDeviceWaitIdle, VkResult(VkDevice));
+  MAKE_MOCK1(vkEndCommandBuffer, VkResult(VkCommandBuffer));
+  MAKE_MOCK4(vkEnumerateDeviceExtensionProperties,
+      VkResult(
+          VkPhysicalDevice, const char *, uint32_t *, VkExtensionProperties *));
+  MAKE_MOCK2(vkEnumerateInstanceLayerProperties,
+      VkResult(uint32_t *, VkLayerProperties *));
+  MAKE_MOCK3(vkEnumeratePhysicalDevices,
+      VkResult(VkInstance, uint32_t *, VkPhysicalDevice *));
+  MAKE_MOCK4(vkFreeCommandBuffers,
+      void(VkDevice, VkCommandPool, uint32_t, const VkCommandBuffer *));
+  MAKE_MOCK4(vkGetDeviceQueue, void(VkDevice, uint32_t, uint32_t, VkQueue *));
+  MAKE_MOCK2(
+      vkGetInstanceProcAddr, PFN_vkVoidFunction(VkInstance, const char *));
+  MAKE_MOCK2(vkGetPhysicalDeviceMemoryProperties,
+      void(VkPhysicalDevice, VkPhysicalDeviceMemoryProperties *));
+  MAKE_MOCK2(vkGetPhysicalDeviceProperties,
+      void(VkPhysicalDevice, VkPhysicalDeviceProperties *));
+  MAKE_MOCK3(vkGetPhysicalDeviceQueueFamilyProperties,
+      void(VkPhysicalDevice, uint32_t *, VkQueueFamilyProperties *));
+  MAKE_MOCK3(vkGetPhysicalDeviceSurfaceCapabilitiesKHR,
+      VkResult(
+          VkPhysicalDevice a, VkSurfaceKHR b, VkSurfaceCapabilitiesKHR *c));
+  MAKE_MOCK4(vkGetPhysicalDeviceSurfaceFormatsKHR,
+      VkResult(
+          VkPhysicalDevice, VkSurfaceKHR, uint32_t *, VkSurfaceFormatKHR *));
+  MAKE_MOCK4(vkGetPhysicalDeviceSurfacePresentModesKHR,
+      VkResult(VkPhysicalDevice, VkSurfaceKHR, uint32_t *, VkPresentModeKHR *));
+  MAKE_MOCK4(vkGetPhysicalDeviceSurfaceSupportKHR,
+      VkResult(VkPhysicalDevice, uint32_t, VkSurfaceKHR, VkBool32 *));
+  MAKE_MOCK4(vkGetSwapchainImagesKHR,
+      VkResult(VkDevice, VkSwapchainKHR, uint32_t *, VkImage *));
+  MAKE_MOCK2(vkQueuePresentKHR, VkResult(VkQueue, const VkPresentInfoKHR *));
+  MAKE_MOCK4(vkQueueSubmit,
+      VkResult(VkQueue, uint32_t, const VkSubmitInfo *, VkFence));
+  MAKE_MOCK3(vkResetFences, VkResult(VkDevice, uint32_t, const VkFence *));
+  MAKE_MOCK5(vkWaitForFences,
+      VkResult(VkDevice, uint32_t, const VkFence *, VkBool32, uint64_t));
+  MAKE_MOCK4(vkCreateDebugUtilsMessengerEXT,
+      VkResult(VkInstance,
+          const VkDebugUtilsMessengerCreateInfoEXT *,
+          const VkAllocationCallbacks *,
+          VkDebugUtilsMessengerEXT *));
+};
+
+extern vulkan_mock vkMock;
+
+#endif // NEBULA_TEST_VULKAN_MOCK_H

--- a/test/vulkan-mock.h
+++ b/test/vulkan-mock.h
@@ -8,6 +8,7 @@
 #include <GLFW/glfw3.h>
 
 #include <string>
+#include <cassert>
 
 class vulkan_mock {
 private:
@@ -15,16 +16,45 @@ private:
   VkInstance testVkInstance;
   VkDebugUtilsMessengerEXT testDUMEXT;
   VkSurfaceKHR testSurface;
+  VkPhysicalDevice testPhysDev;
+  VkDevice testLogDev;
+  VkQueue testCombinedQueue;
+  VkSwapchainKHR testSwapChain;
   const char *testSurfaceExt;
   const char *testSurfaceExts[2];
   void *windowUP = nullptr;
+  uint32_t testSwapChainImageCount;
+  uint32_t testImageCur = 0;
   std::stack<std::unique_ptr<trompeloeil::expectation>> expectations;
   int width;
   int height;
   std::string title;
 
+  void fillSurfCaps(VkSurfaceCapabilitiesKHR &caps);
+  void fillSurfFmt(VkSurfaceFormatKHR &fmt);
+  void fillPhysDevProps(VkPhysicalDeviceProperties &props);
+  void fillDevExtProps(VkExtensionProperties &props);
+  void fillPhysDevMemProps(VkPhysicalDeviceMemoryProperties &props);
+  void genImgHandles(uint32_t n, VkImage *images);
+
 public:
-  void clearExpectations();
+  static vulkan_mock *&instance()
+  {
+    static vulkan_mock *obj = nullptr;
+    return obj;
+  }
+  vulkan_mock()
+  {
+    assert(instance() == nullptr);
+    instance() = this;
+  }
+  ~vulkan_mock()
+  {
+    assert(instance() == this);
+    instance() = nullptr;
+  }
+  vulkan_mock(const vulkan_mock &) = delete;
+  vulkan_mock &operator=(const vulkan_mock &) = delete;
   void mockGraphics();
 
   MAKE_MOCK2(glfwSetWindowShouldClose, void(GLFWwindow *, int));

--- a/test/vulkan-mock.h
+++ b/test/vulkan-mock.h
@@ -20,11 +20,15 @@ private:
   VkDevice testLogDev;
   VkQueue testCombinedQueue;
   VkSwapchainKHR testSwapChain;
+  VkRenderPass testRenderPass;
+  VkPipelineLayout testPipeLayout;
+  VkCommandPool testCmdPool;
   const char *testSurfaceExt;
   const char *testSurfaceExts[2];
   void *windowUP = nullptr;
   uint32_t testSwapChainImageCount;
-  uint32_t testImageCur = 0;
+  uint32_t testImageCur  = 0;
+  uint32_t testDrawImage = 0;
   std::stack<std::unique_ptr<trompeloeil::expectation>> expectations;
   int width;
   int height;
@@ -36,6 +40,11 @@ private:
   void fillDevExtProps(VkExtensionProperties &props);
   void fillPhysDevMemProps(VkPhysicalDeviceMemoryProperties &props);
   void genImgHandles(uint32_t n, VkImage *images);
+  void makePipelines(
+      uint32_t n, const VkGraphicsPipelineCreateInfo *info, VkPipeline *p);
+  void fillCmdBuffer(uint32_t n, VkCommandBuffer *bufs);
+  bool validCmdBuffer(VkCommandBuffer &b);
+  void nextImage(uint32_t *n);
 
 public:
   static vulkan_mock *&instance()
@@ -231,6 +240,9 @@ public:
           const VkDebugUtilsMessengerCreateInfoEXT *,
           const VkAllocationCallbacks *,
           VkDebugUtilsMessengerEXT *));
+  MAKE_MOCK3(vkDestroyDebugUtilsMessengerEXT,
+      void(
+          VkInstance, VkDebugUtilsMessengerEXT, const VkAllocationCallbacks *));
 };
 
 extern vulkan_mock vkMock;


### PR DESCRIPTION
First pass on mocking GLFW and Vulkan to allow tests to run headless, and permit controlled behavior of GLFW and Vulkan during testing.