### PR TITLE
Implement Index Buffering

### DIFF
--- a/src/graphics.cc
+++ b/src/graphics.cc
@@ -64,9 +64,12 @@ SCENARIO("class graphics")
 
 namespace nebula {
 
-const std::vector<vertex> vertices = {{{0.0f, -0.5f}, {1.0f, 0.0f, 0.0f}},
-    {{0.5f, 0.5f}, {0.0f, 1.0f, 0.0f}},
-    {{-0.5f, 0.5f}, {0.0f, 0.0f, 1.0f}}};
+const std::vector<vertex> vertices = {{{-0.5f, -0.5f}, {1.0f, 0.0f, 0.0f}},
+    {{0.5f, -0.5f}, {0.0f, 1.0f, 0.0f}},
+    {{0.5f, 0.5f}, {0.0f, 0.0f, 1.0f}},
+    {{-0.5f, 0.5f}, {1.0f, 1.0f, 1.0f}}};
+
+const std::vector<uint16_t> indices = {0, 1, 2, 2, 3, 0};
 
 graphics::graphics(uint32_t width,
     uint32_t height,
@@ -100,6 +103,7 @@ graphics::graphics(uint32_t width,
   createFramebuffers();
   createCommandPool();
   createVertexBuffer();
+  createIndexBuffer();
   createCommandBuffers();
   createSyncObjects();
 }
@@ -142,6 +146,12 @@ void graphics::destroyLogicalDevice()
 void graphics::destroyBuffers()
 {
   LOG_SCOPE_FUNCTION(INFO);
+  if (_indexBuffer) {
+    vkDestroyBuffer(_logicalDevice, _indexBuffer, nullptr);
+  }
+  if (_indexBufferMemory) {
+    vkFreeMemory(_logicalDevice, _indexBufferMemory, nullptr);
+  }
   if (_vertexBuffer) {
     vkDestroyBuffer(_logicalDevice, _vertexBuffer, nullptr);
   }
@@ -1146,7 +1156,10 @@ void graphics::createCommandBuffers()
     VkBuffer vertexBuffers[] = {_vertexBuffer};
     VkDeviceSize offsets[]   = {0};
     vkCmdBindVertexBuffers(_commandBuffers[i], 0, 1, vertexBuffers, offsets);
-    vkCmdDraw(_commandBuffers[i], 3, 1, 0, 0);
+    vkCmdBindIndexBuffer(
+        _commandBuffers[i], _indexBuffer, 0, VK_INDEX_TYPE_UINT16);
+    vkCmdDrawIndexed(
+        _commandBuffers[i], static_cast<uint32_t>(indices.size()), 1, 0, 0, 0);
     vkCmdEndRenderPass(_commandBuffers[i]);
     if (vkEndCommandBuffer(_commandBuffers[i]) != VK_SUCCESS) {
       LOG_S(ERROR) << "Vulkan: failed to record command buffer";
@@ -1362,6 +1375,31 @@ void graphics::createVertexBuffer()
       _vertexBuffer,
       _vertexBufferMemory);
   copyBuffer(stagingBuffer, _vertexBuffer, bufferSize);
+  vkDestroyBuffer(_logicalDevice, stagingBuffer, nullptr);
+  vkFreeMemory(_logicalDevice, stagingBufferMemory, nullptr);
+}
+
+void graphics::createIndexBuffer()
+{
+  VkDeviceSize bufferSize = sizeof(indices[0]) * indices.size();
+  VkBuffer stagingBuffer;
+  VkDeviceMemory stagingBufferMemory;
+  createBuffer(bufferSize,
+      VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
+          | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+      stagingBuffer,
+      stagingBufferMemory);
+  void *data;
+  vkMapMemory(_logicalDevice, stagingBufferMemory, 0, bufferSize, 0, &data);
+  memcpy(data, indices.data(), (size_t)bufferSize);
+  vkUnmapMemory(_logicalDevice, stagingBufferMemory);
+  createBuffer(bufferSize,
+      VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
+      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+      _indexBuffer,
+      _indexBufferMemory);
+  copyBuffer(stagingBuffer, _indexBuffer, bufferSize);
   vkDestroyBuffer(_logicalDevice, stagingBuffer, nullptr);
   vkFreeMemory(_logicalDevice, stagingBufferMemory, nullptr);
 }

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -103,6 +103,8 @@ private:
   bool _framebufferResized;
   VkBuffer _vertexBuffer;
   VkDeviceMemory _vertexBufferMemory;
+  VkBuffer _indexBuffer;
+  VkDeviceMemory _indexBufferMemory;
 
   const std::vector<const char *> _validationLayers
       = {"VK_LAYER_KHRONOS_validation"};
@@ -153,6 +155,7 @@ private:
       VkBuffer &buffer,
       VkDeviceMemory &bufferMemory);
   void createVertexBuffer();
+  void createIndexBuffer();
   void copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size);
   uint32_t findMemoryType(
       uint32_t typeFilter, VkMemoryPropertyFlags properties);

--- a/test/vulkan-mock.cc
+++ b/test/vulkan-mock.cc
@@ -707,6 +707,26 @@ VkResult vkQueueWaitIdle(VkQueue a)
   assert(vkMock);
   return vkMock->vkQueueWaitIdle(a);
 }
+
+void vkCmdBindIndexBuffer(
+    VkCommandBuffer a, VkBuffer b, VkDeviceSize c, VkIndexType d)
+{
+  auto vkMock = vulkanMock::instance();
+  assert(vkMock);
+  vkMock->vkCmdBindIndexBuffer(a, b, c, d);
+}
+
+void vkCmdDrawIndexed(VkCommandBuffer a,
+    uint32_t b,
+    uint32_t c,
+    uint32_t d,
+    int32_t e,
+    uint32_t f)
+{
+  auto vkMock = vulkanMock::instance();
+  assert(vkMock);
+  vkMock->vkCmdDrawIndexed(a, b, c, d, e, f);
+}
 }
 
 void vulkanMock::fillSurfCaps(VkSurfaceCapabilitiesKHR &caps)
@@ -1251,4 +1271,7 @@ void vulkanMock::mockGraphics()
   expectations.push(NAMED_ALLOW_CALL(*this, vkCmdCopyBuffer(_, _, _, _, _)));
   expectations.push(
       NAMED_ALLOW_CALL(*this, vkQueueWaitIdle(_)).RETURN(VK_SUCCESS));
+  expectations.push(NAMED_ALLOW_CALL(*this, vkCmdBindIndexBuffer(_, _, _, _)));
+  expectations.push(
+      NAMED_ALLOW_CALL(*this, vkCmdDrawIndexed(_, _, _, _, _, _)));
 }

--- a/test/vulkan-mock.h
+++ b/test/vulkan-mock.h
@@ -325,6 +325,10 @@ public:
       void(
           VkCommandBuffer, VkBuffer, VkBuffer, uint32_t, const VkBufferCopy *));
   MAKE_MOCK1(vkQueueWaitIdle, VkResult(VkQueue));
+  MAKE_MOCK4(vkCmdBindIndexBuffer,
+      void(VkCommandBuffer, VkBuffer, VkDeviceSize, VkIndexType));
+  MAKE_MOCK6(vkCmdDrawIndexed,
+      void(VkCommandBuffer, uint32_t, uint32_t, uint32_t, int32_t, uint32_t));
 };
 
 extern vulkanMock vkMock;


### PR DESCRIPTION
### Description
Changed input data to provide an index buffer in addition to the vertex buffer. Implemented mocking needed for new functions used. Implemented code needed to provide the index buffer to Vulkan.

### Checklist
- [x] Reference the issue this PR fixes: #71
- [x] Create tests which fail without the changes (if possible/relevant)
- [x] Verify the code compiles correctly
- [x] Verify all tests passing
- [x] Add yourself/the copyright holder to the AUTHORS.md file
- [x] Verify the changes are licensed compatible to the LGPL-2.1 License
