### PR TITLE
Create descriptor pool and sets to send uniforms to Vulkan

### DIFF
--- a/src/graphics.h
+++ b/src/graphics.h
@@ -31,9 +31,9 @@ struct uniformBufferObject {
 };
 
 class graphics {
-public:
-  class pipeline {
-  private:
+  // public:
+private:
+  struct pipeline {
     VkDevice _device;
     VkPipelineLayout _pipelineLayout;
     VkPipeline _graphicsPipeline;
@@ -68,7 +68,6 @@ public:
     void setupPipelineLayout(VkRenderPass renderPass);
     void createDescriptorSetLayout();
 
-  public:
     pipeline(VkDevice device,
         const std::string &vertShader,
         const std::string &fragShader,
@@ -81,7 +80,7 @@ public:
     }
   };
 
-private:
+  // private:
   uint32_t _width;
   uint32_t _height;
   GLFWwindow *_window;
@@ -115,6 +114,8 @@ private:
   VkDeviceMemory _indexBufferMemory;
   std::vector<VkBuffer> _uniformBuffers;
   std::vector<VkDeviceMemory> _uniformBuffersMemory;
+  VkDescriptorPool _descriptorPool;
+  std::vector<VkDescriptorSet> _descriptorSets;
 
   const std::vector<const char *> _validationLayers
       = {"VK_LAYER_KHRONOS_validation"};
@@ -172,6 +173,8 @@ private:
       uint32_t typeFilter, VkMemoryPropertyFlags properties);
   void destroyBuffers();
   void updateUniformBuffer(uint32_t currentImage);
+  void createDescriptorPool();
+  void createDescriptorSets();
 
   static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
       VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,

--- a/test/vulkan-mock.cc
+++ b/test/vulkan-mock.cc
@@ -745,6 +745,57 @@ void vkDestroyDescriptorSetLayout(
   assert(vkMock);
   vkMock->vkDestroyDescriptorSetLayout(a, b, c);
 }
+
+VkResult vkCreateDescriptorPool(VkDevice a,
+    const VkDescriptorPoolCreateInfo *b,
+    const VkAllocationCallbacks *c,
+    VkDescriptorPool *d)
+{
+  auto vkMock = vulkanMock::instance();
+  assert(vkMock);
+  return vkMock->vkCreateDescriptorPool(a, b, c, d);
+}
+
+void vkDestroyDescriptorPool(
+    VkDevice a, VkDescriptorPool b, const VkAllocationCallbacks *c)
+{
+  auto vkMock = vulkanMock::instance();
+  assert(vkMock);
+  vkMock->vkDestroyDescriptorPool(a, b, c);
+}
+
+VkResult vkAllocateDescriptorSets(
+    VkDevice a, const VkDescriptorSetAllocateInfo *b, VkDescriptorSet *c)
+{
+  auto vkMock = vulkanMock::instance();
+  assert(vkMock);
+  return vkMock->vkAllocateDescriptorSets(a, b, c);
+}
+
+void vkUpdateDescriptorSets(VkDevice a,
+    uint32_t b,
+    const VkWriteDescriptorSet *c,
+    uint32_t d,
+    const VkCopyDescriptorSet *e)
+{
+  auto vkMock = vulkanMock::instance();
+  assert(vkMock);
+  vkMock->vkUpdateDescriptorSets(a, b, c, d, e);
+}
+
+void vkCmdBindDescriptorSets(VkCommandBuffer a,
+    VkPipelineBindPoint b,
+    VkPipelineLayout c,
+    uint32_t d,
+    uint32_t e,
+    const VkDescriptorSet *f,
+    uint32_t g,
+    const uint32_t *h)
+{
+  auto vkMock = vulkanMock::instance();
+  assert(vkMock);
+  vkMock->vkCmdBindDescriptorSets(a, b, c, d, e, f, g, h);
+}
 }
 
 void vulkanMock::fillSurfCaps(VkSurfaceCapabilitiesKHR &caps)
@@ -944,6 +995,15 @@ void *vulkanMock::mapMem(VkDeviceMemory a, uint64_t size)
 void vulkanMock::unmapMem(VkDeviceMemory a)
 {
   (reinterpret_cast<mockMem *>(a))->unmap();
+}
+
+void vulkanMock::allocDescriptorSets(
+    const VkDescriptorSetAllocateInfo *pAllocateInfo,
+    VkDescriptorSet pDescriptorSets[])
+{
+  for (uint32_t i = 0; i < pAllocateInfo->descriptorSetCount; i++) {
+    pDescriptorSets[i] = reinterpret_cast<VkDescriptorSet>(0xF00 + i);
+  }
 }
 
 void vulkanMock::mockGraphics()
@@ -1300,4 +1360,19 @@ void vulkanMock::mockGraphics()
           .RETURN(VK_SUCCESS));
   expectations.push(
       NAMED_ALLOW_CALL(*this, vkDestroyDescriptorSetLayout(testLogDev, _, _)));
+  expectations.push(
+      NAMED_ALLOW_CALL(*this, vkCreateDescriptorPool(testLogDev, _, nullptr, _))
+          .SIDE_EFFECT(*_4 = reinterpret_cast<VkDescriptorPool>(
+                           const_cast<VkDescriptorPoolCreateInfo *>(_2)))
+          .RETURN(VK_SUCCESS));
+  expectations.push(
+      NAMED_ALLOW_CALL(*this, vkDestroyDescriptorPool(testLogDev, _, nullptr)));
+  expectations.push(
+      NAMED_ALLOW_CALL(*this, vkAllocateDescriptorSets(testLogDev, _, _))
+          .SIDE_EFFECT(allocDescriptorSets(_2, _3))
+          .RETURN(VK_SUCCESS));
+  expectations.push(
+      NAMED_ALLOW_CALL(*this, vkUpdateDescriptorSets(testLogDev, _, _, _, _)));
+  expectations.push(
+      NAMED_ALLOW_CALL(*this, vkCmdBindDescriptorSets(_, _, _, _, _, _, _, _)));
 }

--- a/test/vulkan-mock.h
+++ b/test/vulkan-mock.h
@@ -111,6 +111,8 @@ public:
   void setPhysDeviceType(VkPhysicalDeviceType t);
   void framebufferResize(int newW, int newH);
   void setSwapChainOutOfDate();
+  void allocDescriptorSets(const VkDescriptorSetAllocateInfo *pAllocateInfo,
+      VkDescriptorSet *pDescriptorSets);
 
   MAKE_MOCK2(glfwSetWindowShouldClose, void(GLFWwindow *, int));
   MAKE_MOCK0(glfwPollEvents, void());
@@ -336,6 +338,31 @@ public:
           VkDescriptorSetLayout *));
   MAKE_MOCK3(vkDestroyDescriptorSetLayout,
       void(VkDevice, VkDescriptorSetLayout, const VkAllocationCallbacks *));
+  MAKE_MOCK4(vkCreateDescriptorPool,
+      VkResult(VkDevice,
+          const VkDescriptorPoolCreateInfo *,
+          const VkAllocationCallbacks *,
+          VkDescriptorPool *));
+  MAKE_MOCK3(vkDestroyDescriptorPool,
+      void(VkDevice, VkDescriptorPool, const VkAllocationCallbacks *));
+  MAKE_MOCK3(vkAllocateDescriptorSets,
+      VkResult(
+          VkDevice, const VkDescriptorSetAllocateInfo *, VkDescriptorSet *));
+  MAKE_MOCK5(vkUpdateDescriptorSets,
+      void(VkDevice,
+          uint32_t,
+          const VkWriteDescriptorSet *,
+          uint32_t,
+          const VkCopyDescriptorSet *));
+  MAKE_MOCK8(vkCmdBindDescriptorSets,
+      void(VkCommandBuffer,
+          VkPipelineBindPoint,
+          VkPipelineLayout,
+          uint32_t,
+          uint32_t,
+          const VkDescriptorSet *,
+          uint32_t,
+          const uint32_t *));
 };
 
 extern vulkanMock vkMock;


### PR DESCRIPTION
### Description
Create descriptor pool and sets, and bind to them in the command buffer.

### Checklist
- [x] Reference the issue this PR fixes: #74
- [x] Create tests which fail without the changes (if possible/relevant)
- [x] Verify the code compiles correctly
- [x] Verify all tests passing
- [x] Add yourself/the copyright holder to the AUTHORS.md file
- [x] Verify the changes are licensed compatible to the LGPL-2.1 License
