### PR TITLE
Code Coverage adjustments

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,7 +6,12 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: "70...90"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
 
 parsers:
   gcov:

--- a/test/vulkan-mock.cc
+++ b/test/vulkan-mock.cc
@@ -16,7 +16,6 @@ extern "C" {
 
 void glfwSetWindowShouldClose(GLFWwindow *a, int b)
 {
-  LOG_SCOPE_FUNCTION(9);
   auto vkMock = vulkanMock::instance();
   assert(vkMock);
   vkMock->glfwSetWindowShouldClose(a, b);
@@ -127,7 +126,6 @@ GLFWframebuffersizefun glfwSetFramebufferSizeCallback(
 
 GLFWkeyfun glfwSetKeyCallback(GLFWwindow *a, GLFWkeyfun b)
 {
-  LOG_SCOPE_FUNCTION(9);
   auto vkMock = vulkanMock::instance();
   assert(vkMock);
   return vkMock->glfwSetKeyCallback(a, b);

--- a/test/vulkan-mock.h
+++ b/test/vulkan-mock.h
@@ -1,8 +1,8 @@
 // This document is licensed according to the LGPL v2.1 license
 // Consult the LICENSE file in the root project directory for details
 
-#ifndef NEBULA_TEST_vulkanMock_H
-#define NEBULA_TEST_vulkanMock_H
+#ifndef NEBULA_TEST_VULKAN_MOCK_H
+#define NEBULA_TEST_VULKAN_MOCK_H
 
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
@@ -365,6 +365,4 @@ public:
           const uint32_t *));
 };
 
-extern vulkanMock vkMock;
-
-#endif // NEBULA_TEST_vulkanMock_H
+#endif // NEBULA_TEST_VULKAN_MOCK_H


### PR DESCRIPTION
### Description
Failure paths are not important to test. The code in them is using code that already is known to work via other code paths and with known good throw statements. Obsessive obedience to a code coverage target is unnecessary. Rather, testing should cover as much of the standard operation of the code as is possible.

This PR should adjust the codecov settings to permit a decrease of up to 1% in coverage for a successful status check in PRs, and a decrese in the upper limit of desired coverage (70-100% to 70-90%). It also does some minor adjustments to the Vulkan mocking; fixing incorrect text replacements from a previous commit, and removing unneeded logging commands.

### Checklist
- [x] Reference the issue this PR fixes: #93
- [x] Create tests which fail without the changes (if possible/relevant)
- [x] Verify the code compiles correctly
- [x] Verify all tests passing
- [x] Add yourself/the copyright holder to the AUTHORS.md file
- [x] Verify the changes are licensed compatible to the LGPL-2.1 License
