### PR TITLE
Depth Buffering

### DIFF
--- a/src/graphics.h
+++ b/src/graphics.h
@@ -16,7 +16,7 @@
 namespace nebula {
 
 struct vertex {
-  glm::vec2 pos;
+  glm::vec3 pos;
   glm::vec3 color;
   glm::vec2 texCoord;
   static void getBindingDesc();
@@ -49,6 +49,7 @@ private:
     VkPipelineMultisampleStateCreateInfo _multisampling;
     VkPipelineColorBlendAttachmentState _colorBlendAttachment;
     VkPipelineColorBlendStateCreateInfo _colorBlending;
+    VkPipelineDepthStencilStateCreateInfo _depthStencil;
     VkPipelineLayoutCreateInfo _pipelineLayoutInfo;
     VkGraphicsPipelineCreateInfo _pipelineInfo;
     VkDescriptorSetLayout _descriptorSetLayout;
@@ -66,6 +67,7 @@ private:
     void setupRasterState();
     void setupMultisampling();
     void setupColorBlend();
+    void setupDepthStencil();
     void setupPipelineLayout(VkRenderPass renderPass);
     void createDescriptorSetLayout();
 
@@ -121,6 +123,9 @@ private:
   VkDeviceMemory _textureImageMemory;
   VkImageView _textureImageView;
   VkSampler _textureSampler;
+  VkImage _depthImage;
+  VkDeviceMemory _depthImageMemory;
+  VkImageView _depthImageView;
 
   const std::vector<const char *> _validationLayers
       = {"VK_LAYER_KHRONOS_validation"};
@@ -198,8 +203,15 @@ private:
   void copyBufferToImage(
       VkBuffer buffer, VkImage image, uint32_t width, uint32_t height);
   void createTextureImageView();
-  VkImageView createImageView(VkImage image, VkFormat format);
+  VkImageView createImageView(
+      VkImage image, VkFormat format, VkImageAspectFlags aspectFlags);
   void createTextureSampler();
+  void createDepthResources();
+  VkFormat findSupportedFormat(const std::vector<VkFormat> &candidates,
+      VkImageTiling tiling,
+      VkFormatFeatureFlags features);
+  VkFormat findDepthFormat();
+  bool hasStencilComponent(VkFormat format);
 
   static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
       VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,

--- a/src/shader.vert
+++ b/src/shader.vert
@@ -6,7 +6,7 @@ layout(binding = 0) uniform UniformBufferObject {
     mat4 proj;
 } ubo;
 
-layout(location = 0) in vec2 inPosition;
+layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec3 inColor;
 layout(location = 2) in vec2 inTexCoord;
 
@@ -14,7 +14,7 @@ layout(location = 0) out vec3 fragColor;
 layout(location = 1) out vec2 fragTexCoord;
 
 void main() {
-    gl_Position = ubo.proj * ubo.view * ubo.model * vec4(inPosition, 0.0, 1.0);
+    gl_Position = ubo.proj * ubo.view * ubo.model * vec4(inPosition, 1.0);
     fragColor = inColor;
     fragTexCoord = inTexCoord;
 }

--- a/test/vulkan-mock.cc
+++ b/test/vulkan-mock.cc
@@ -880,6 +880,14 @@ void vkGetPhysicalDeviceFeatures(
   assert(vkMock);
   vkMock->vkGetPhysicalDeviceFeatures(a, b);
 }
+
+void vkGetPhysicalDeviceFormatProperties(
+    VkPhysicalDevice a, VkFormat b, VkFormatProperties *c)
+{
+  auto vkMock = vulkanMock::instance();
+  assert(vkMock);
+  vkMock->vkGetPhysicalDeviceFormatProperties(a, b, c);
+}
 }
 
 void vulkanMock::fillSurfCaps(VkSurfaceCapabilitiesKHR &caps)
@@ -1487,4 +1495,11 @@ void vulkanMock::mockGraphics()
   expectations.push(
       NAMED_ALLOW_CALL(*this, vkGetPhysicalDeviceFeatures(testPhysDev, _))
           .SIDE_EFFECT(_2->samplerAnisotropy = VK_TRUE));
+  expectations.push(
+      NAMED_ALLOW_CALL(
+          *this, vkGetPhysicalDeviceFormatProperties(testPhysDev, _, _))
+          .SIDE_EFFECT(_3->linearTilingFeatures
+                       = VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
+          .SIDE_EFFECT(_3->optimalTilingFeatures
+                       = VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT));
 }

--- a/test/vulkan-mock.h
+++ b/test/vulkan-mock.h
@@ -410,6 +410,8 @@ public:
       void(VkDevice, VkSampler, const VkAllocationCallbacks *));
   MAKE_MOCK2(vkGetPhysicalDeviceFeatures,
       void(VkPhysicalDevice, VkPhysicalDeviceFeatures *));
+  MAKE_MOCK3(vkGetPhysicalDeviceFormatProperties,
+      void(VkPhysicalDevice, VkFormat, VkFormatProperties *));
 };
 
 #endif // NEBULA_TEST_VULKAN_MOCK_H


### PR DESCRIPTION
### Description
Adds depth buffering to pipeline to handle depth testing of opaque 3D geometry.

### Checklist
- [x] Reference the issue this PR fixes: #97
- [x] Create tests which fail without the changes (if possible/relevant)
- [x] Verify the code compiles correctly
- [x] Verify all tests passing
- [x] Add yourself/the copyright holder to the AUTHORS.md file
- [x] Verify the changes are licensed compatible to the LGPL-2.1 License
