### PR TITLE
MipMap Generation at Runtime

### DIFF
--- a/src/graphics.h
+++ b/src/graphics.h
@@ -128,6 +128,7 @@ private:
   std::vector<VkDeviceMemory> _uniformBuffersMemory;
   VkDescriptorPool _descriptorPool;
   std::vector<VkDescriptorSet> _descriptorSets;
+  uint32_t _mipLevels;
   VkImage _textureImage;
   VkDeviceMemory _textureImageMemory;
   VkImageView _textureImageView;
@@ -197,6 +198,7 @@ private:
   void createTextureImage();
   void createImage(uint32_t width,
       uint32_t height,
+      uint32_t mipLevels,
       VkFormat format,
       VkImageTiling tiling,
       VkImageUsageFlags usage,
@@ -208,12 +210,15 @@ private:
   void transitionImageLayout(VkImage image,
       VkFormat format,
       VkImageLayout oldLayout,
-      VkImageLayout newLayout);
+      VkImageLayout newLayout,
+      uint32_t mipLevels);
   void copyBufferToImage(
       VkBuffer buffer, VkImage image, uint32_t width, uint32_t height);
   void createTextureImageView();
-  VkImageView createImageView(
-      VkImage image, VkFormat format, VkImageAspectFlags aspectFlags);
+  VkImageView createImageView(VkImage image,
+      VkFormat format,
+      VkImageAspectFlags aspectFlags,
+      uint32_t mipLevels);
   void createTextureSampler();
   void createDepthResources();
   VkFormat findSupportedFormat(const std::vector<VkFormat> &candidates,
@@ -222,6 +227,11 @@ private:
   VkFormat findDepthFormat();
   bool hasStencilComponent(VkFormat format);
   void loadModel();
+  void generateMipmaps(VkImage image,
+      VkFormat imageFormat,
+      int32_t texWidth,
+      int32_t texHeight,
+      uint32_t mipLevels);
 
   static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
       VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,

--- a/test/vulkan-mock.cc
+++ b/test/vulkan-mock.cc
@@ -888,6 +888,20 @@ void vkGetPhysicalDeviceFormatProperties(
   assert(vkMock);
   vkMock->vkGetPhysicalDeviceFormatProperties(a, b, c);
 }
+
+void vkCmdBlitImage(VkCommandBuffer a,
+    VkImage b,
+    VkImageLayout c,
+    VkImage d,
+    VkImageLayout e,
+    uint32_t f,
+    const VkImageBlit *g,
+    VkFilter h)
+{
+  auto vkMock = vulkanMock::instance();
+  assert(vkMock);
+  vkMock->vkCmdBlitImage(a, b, c, d, e, f, g, h);
+}
 }
 
 void vulkanMock::fillSurfCaps(VkSurfaceCapabilitiesKHR &caps)
@@ -1501,5 +1515,8 @@ void vulkanMock::mockGraphics()
           .SIDE_EFFECT(_3->linearTilingFeatures
                        = VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
           .SIDE_EFFECT(_3->optimalTilingFeatures
-                       = VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT));
+                       = VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT
+                       | VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT));
+  expectations.push(
+      NAMED_ALLOW_CALL(*this, vkCmdBlitImage(_, _, _, _, _, _, _, _)));
 }

--- a/test/vulkan-mock.h
+++ b/test/vulkan-mock.h
@@ -412,6 +412,15 @@ public:
       void(VkPhysicalDevice, VkPhysicalDeviceFeatures *));
   MAKE_MOCK3(vkGetPhysicalDeviceFormatProperties,
       void(VkPhysicalDevice, VkFormat, VkFormatProperties *));
+  MAKE_MOCK8(vkCmdBlitImage,
+      void(VkCommandBuffer,
+          VkImage,
+          VkImageLayout,
+          VkImage,
+          VkImageLayout,
+          uint32_t,
+          const VkImageBlit *,
+          VkFilter));
 };
 
 #endif // NEBULA_TEST_VULKAN_MOCK_H


### PR DESCRIPTION
### Description
While it is unlikely to be needed much, the code to generate mipmaps at runtime is coded in and currently active. Refactoring later will need to adjust this so that it is an optional, limited, or even ignored aspect of texture mapping.

### Checklist
- [x] Reference the issue this PR fixes: #100
- [x] Create tests which fail without the changes (if possible/relevant)
- [x] Verify the code compiles correctly
- [x] Verify all tests passing
- [x] Add yourself/the copyright holder to the AUTHORS.md file
- [x] Verify the changes are licensed compatible to the LGPL-2.1 License
